### PR TITLE
Adding initial project (OSK-1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+src/.vs
+src/*/bin
+src/*/obj
+.github

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -31,29 +31,3 @@ jobs:
       run: dotnet build --no-restore ./src/${{ github.event.repository.name }}.sln
     - name: Test
       run: dotnet test --no-build --verbosity normal ./src/${{ github.event.repository.name }}.sln
-
-# DOCKER STUFF
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v4
-      with:
-        images: ${{ secrets.DOCKERHUB_USERNAME }}/umlgenerator-experiment
-        tags: |
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern={{version}},value=0.0.1-alpha
-          type=sha
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Login to DockerHub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - uses: docker/build-push-action@v5
-      with:
-        context: .
-        build-args: VERSION=0.0.1-alpha
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -1,0 +1,59 @@
+name: .NET Test Automation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: [ '8.0.x' ]
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: ${{ matrix.dotnet-version }}
+    - name: Restore dependencies
+      run: >-
+        dotnet restore ./src/${{ github.event.repository.name }}.sln
+    - name: Build
+      run: dotnet build --no-restore ./src/${{ github.event.repository.name }}.sln
+    - name: Test
+      run: dotnet test --no-build --verbosity normal ./src/${{ github.event.repository.name }}.sln
+
+# DOCKER STUFF
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ secrets.DOCKERHUB_USERNAME }}/umlgenerator-experiment
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}},value=0.0.1-alpha
+          type=sha
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to DockerHub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - uses: docker/build-push-action@v5
+      with:
+        context: .
+        build-args: VERSION=0.0.1-alpha
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/issueLinker-workflow.yml
+++ b/.github/workflows/issueLinker-workflow.yml
@@ -1,0 +1,23 @@
+name: Attach Issue Link
+
+on:
+  pull_request:
+    branches: [ main ]
+    
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: the-wright-jamie/update-pr-info-action@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        head-branch-regex: '\d+'
+        body-template: |
+          Fixes #%headbranch%
+        body-update-action: 'suffix'
+        body-uppercase-head-match: false
+        lowercase-branch: false

--- a/.github/workflows/publish-packages-workflow.yml
+++ b/.github/workflows/publish-packages-workflow.yml
@@ -1,0 +1,29 @@
+name: Publish packages
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+permissions:
+  packages: write
+  contents: read
+    
+jobs:
+  publish-nuget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get the version
+        id: get_version
+        run: echo "PACKAGE_VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT" 
+      - uses: actions/setup-dotnet@v4.0.0
+        with:
+          dotnet-version: '8.0.x' # SDK Version to use.
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_TOKEN }}
+      - run: dotnet build --configuration Release ./src /p:Version=${{ steps.get_version.outputs.PACKAGE_VERSION }}
+      - name: Create the package
+        run: dotnet pack --configuration Release ./src -o . /p:Version=${{ steps.get_version.outputs.PACKAGE_VERSION }}
+      - name: Publish the package to Nuget
+        run: dotnet nuget push ./*.nupkg --api-key ${{ secrets.NUGET_TOKEN }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish-packages-workflow.yml
+++ b/.github/workflows/publish-packages-workflow.yml
@@ -27,3 +27,39 @@ jobs:
         run: dotnet pack --configuration Release ./src -o . /p:Version=${{ steps.get_version.outputs.PACKAGE_VERSION }}
       - name: Publish the package to Nuget
         run: dotnet nuget push ./*.nupkg --api-key ${{ secrets.NUGET_TOKEN }} --source https://api.nuget.org/v3/index.json
+  publish-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get the version
+        id: get_version
+        run: echo "PACKAGE_VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT" 
+      - uses: actions/setup-dotnet@v4.0.0
+        with:
+          dotnet-version: '8.0.x' # SDK Version to use.
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_TOKEN }}
+# DOCKER STUFF
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/umlgenerator
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}},value=${{ steps.get_version.outputs.PACKAGE_VERSION }}
+            type=sha
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: VERSION=${{ steps.get_version.outputs.PACKAGE_VERSION }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # OSK.UML
-A configurable library for creating UML diagrams from files or directories.
+A configurable library for creating UML diagrams from files or directories. 
+
+Currently supports C# files out the gate, but parsing should be easily configurable by creating new definition files 
+either within this repository or the consumer project.
+
+# Docker supprt
+A docker image has been deployed to https://hub.docker.com/repository/docker/blankdev117/umlgenerator and can be used to generate UML diagrams within a container

--- a/dockerfile
+++ b/dockerfile
@@ -9,7 +9,7 @@ COPY src/OSK.UML.CommandLine/*.csproj ./OSK.UML.CommandLine/
 COPY src/OSK.UML/*.csproj ./OSK.UML/
 COPY src/OSK.UML.Framework/*.csproj ./OSK.UML.Framework/
 COPY src/OSK.UML.Exporters.PlantUML/*.csproj ./OSK.UML.Exporters.PlantUML/
-RUN dotnet restore Experimental.Uml.sln
+RUN dotnet restore OSK.UML.sln
 
 COPY ./src ./
 RUN dotnet pack -c Release -p:VERSION=${VERSION} ./OSK.UML.CommandLine/OSK.UML.CommandLine.csproj

--- a/dockerfile
+++ b/dockerfile
@@ -9,6 +9,9 @@ COPY src/OSK.UML.CommandLine/*.csproj ./OSK.UML.CommandLine/
 COPY src/OSK.UML/*.csproj ./OSK.UML/
 COPY src/OSK.UML.Framework/*.csproj ./OSK.UML.Framework/
 COPY src/OSK.UML.Exporters.PlantUML/*.csproj ./OSK.UML.Exporters.PlantUML/
+
+RUN ls
+
 RUN dotnet restore ./OSK.UML.sln
 
 COPY ./src ./

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,43 @@
+ARG VERSION=0.1.0-local
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG VERSION
+WORKDIR /app
+
+COPY src/*.sln ./
+COPY src/OSK.UML.CommandLine/*.csproj ./OSK.UML.CommandLine/
+COPY src/OSK.UML/*.csproj ./OSK.UML/
+COPY src/OSK.UML.Parsing/*.csproj ./OSK.UML.Parsing/
+COPY src/OSK.UML.PlantUML/*.csproj ./OSK.UML.PlantUML/
+RUN dotnet restore Experimental.Uml.sln
+
+COPY ./src ./
+RUN dotnet pack -c Release -p:VERSION=${VERSION} ./OSK.UML.CommandLine/OSK.UML.CommandLine.csproj
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as packer
+ARG VERSION
+WORKDIR /app
+
+RUN groupadd -g 1000 -r umlgenerator && useradd --no-log-init -u 1000 -r -g umlgenerator umlgenerator && \
+    mkdir -p /home/umlgenerator && \
+    mkdir -p /home/umlgenerator/plantuml && \
+    chown umlgenerator:umlgenerator /home/umlgenerator
+ENV HOME=/home/umlgenerator PATH=/home/umlgenerator/.dotnet/tools:${PATH}
+USER umlgenerator
+
+COPY --from=build /app/OSK.UML.CommandLine/bin/Release/OSK.UML.CommandLine.*.nupkg ./
+RUN dotnet tool install --global --add-source /app --version ${VERSION} OSK.UML.CommandLine
+
+ENV PATH="/root/.dotnet/tools:${PATH}"
+
+FROM mcr.microsoft.com/dotnet/runtime:8.0
+RUN apt-get update && apt-get install -y \
+ graphviz
+
+ENV JAVA_HOME /usr/lib/jvm/msopenjdk-17-amd64
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=mcr.microsoft.com/openjdk/jdk:17-ubuntu $JAVA_HOME $JAVA_HOME
+
+COPY --from=packer /home/umlgenerator/.dotnet/tools /opt/bin
+
+ENV PATH="/opt/bin:${PATH}"

--- a/dockerfile
+++ b/dockerfile
@@ -9,7 +9,7 @@ COPY src/OSK.UML.CommandLine/*.csproj ./OSK.UML.CommandLine/
 COPY src/OSK.UML/*.csproj ./OSK.UML/
 COPY src/OSK.UML.Framework/*.csproj ./OSK.UML.Framework/
 COPY src/OSK.UML.Exporters.PlantUML/*.csproj ./OSK.UML.Exporters.PlantUML/
-RUN dotnet restore src/OSK.UML.sln
+RUN dotnet restore ./OSK.UML.sln
 
 COPY ./src ./
 RUN dotnet pack -c Release -p:VERSION=${VERSION} ./OSK.UML.CommandLine/OSK.UML.CommandLine.csproj

--- a/dockerfile
+++ b/dockerfile
@@ -9,7 +9,7 @@ COPY src/OSK.UML.CommandLine/*.csproj ./OSK.UML.CommandLine/
 COPY src/OSK.UML/*.csproj ./OSK.UML/
 COPY src/OSK.UML.Framework/*.csproj ./OSK.UML.Framework/
 COPY src/OSK.UML.Exporters.PlantUML/*.csproj ./OSK.UML.Exporters.PlantUML/
-RUN dotnet restore OSK.UML.sln
+RUN dotnet restore src/OSK.UML.sln
 
 COPY ./src ./
 RUN dotnet pack -c Release -p:VERSION=${VERSION} ./OSK.UML.CommandLine/OSK.UML.CommandLine.csproj

--- a/dockerfile
+++ b/dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 COPY src/*.sln ./
 COPY src/OSK.UML.CommandLine/*.csproj ./OSK.UML.CommandLine/
 COPY src/OSK.UML/*.csproj ./OSK.UML/
-COPY src/OSK.UML.Parsing/*.csproj ./OSK.UML.Parsing/
-COPY src/OSK.UML.PlantUML/*.csproj ./OSK.UML.PlantUML/
+COPY src/OSK.UML.Framework/*.csproj ./OSK.UML.Framework/
+COPY src/OSK.UML.Exporters.PlantUML/*.csproj ./OSK.UML.Exporters.PlantUML/
 RUN dotnet restore Experimental.Uml.sln
 
 COPY ./src ./

--- a/dockerfile
+++ b/dockerfile
@@ -7,11 +7,10 @@ WORKDIR /app
 COPY src/*.sln ./
 COPY src/OSK.UML.CommandLine/*.csproj ./OSK.UML.CommandLine/
 COPY src/OSK.UML/*.csproj ./OSK.UML/
+COPY src/OSK.UML.UnitTests/*.csproj ./OSK.UML.UnitTests/
 COPY src/OSK.UML.Framework/*.csproj ./OSK.UML.Framework/
+COPY src/OSK.UML.Framework.UnitTests/*.csproj ./OSK.UML.Framework.UnitTests/
 COPY src/OSK.UML.Exporters.PlantUML/*.csproj ./OSK.UML.Exporters.PlantUML/
-
-RUN ls
-
 RUN dotnet restore ./OSK.UML.sln
 
 COPY ./src ./
@@ -31,7 +30,7 @@ USER umlgenerator
 COPY --from=build /app/OSK.UML.CommandLine/bin/Release/OSK.UML.CommandLine.*.nupkg ./
 RUN dotnet tool install --global --add-source /app --version ${VERSION} OSK.UML.CommandLine
 
-ENV PATH="/root/.dotnet/tools:${PATH}"
+ENV PATH "/root/.dotnet/tools:${PATH}"
 
 FROM mcr.microsoft.com/dotnet/runtime:8.0
 RUN apt-get update && apt-get install -y \
@@ -43,4 +42,4 @@ COPY --from=mcr.microsoft.com/openjdk/jdk:17-ubuntu $JAVA_HOME $JAVA_HOME
 
 COPY --from=packer /home/umlgenerator/.dotnet/tools /opt/bin
 
-ENV PATH="/opt/bin:${PATH}"
+ENV PATH "/opt/bin:${PATH}"

--- a/src/OSK.UML.CommandLine/Commands/GenerateUmlCommand.cs
+++ b/src/OSK.UML.CommandLine/Commands/GenerateUmlCommand.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Extensions.Logging;
+using OSK.Functions.Outputs.Abstractions;
+using OSK.UML.Options;
+using OSK.UML.Ports;
+using System.Diagnostics;
+
+namespace OSK.UML.CommandLine.Commands
+{
+    public class GenerateUmlCommand(GenerateUmlOptions options,
+        IUmlGenerator generator, IUmlExporter exporter,
+        ILogger<GenerateUmlCommand> logger)
+    {
+        #region GenerateUmlCommand
+
+        public async Task<IOutput> ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            logger.LogDebug("Generating UML diagram for {path} with a depth of {depth}...", options.Path, options.DirectoryDepth);
+            var stopwatch = new Stopwatch();
+
+            stopwatch.Start();
+            var generationResult = await generator.GenerateUmlAsync(options.Path, options.Name, new UmlGenerationOptions()
+            {
+                DirectoryDepth = options.DirectoryDepth,
+                FileExtensionPattern = string.Join(",", options.FileTypes)
+            }, cancellationToken);
+            stopwatch.Stop();
+
+            logger.LogDebug("Uml generation completed in {seconds} seconds.", Math.Round(stopwatch.Elapsed.TotalSeconds, 3));
+            if (!generationResult.IsSuccessful)
+            {
+                logger.LogError("Uml generation failure: {error}", generationResult.GetErrorString());
+                return generationResult;
+            }
+            logger.LogInformation("Uml generation successful. Parsed {umlObjectCount} uml objects from {fileCount} files discovered.", generationResult.Value.TotalUmlObjectsDiscovered, generationResult.Value.TotalFilesChecked);
+
+            logger.LogDebug("Exporting UML diagram to {outputPath}...", options.OutputPath);
+
+            stopwatch.Restart();
+            var exportResult = await exporter.ExportAsync(options.OutputPath, generationResult.Value.UmlDiagram, cancellationToken);
+            stopwatch.Stop();
+
+            logger.LogDebug("Uml export completed in {seconds} seconds.", Math.Round(stopwatch.Elapsed.TotalSeconds, 3));
+            if (!generationResult.IsSuccessful)
+            {
+                logger.LogError("Uml export failure: {error}", exportResult.GetErrorString());
+                return generationResult;
+            }
+            logger.LogInformation("Uml export successful.");
+
+            return exportResult;
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.UML.CommandLine/Commands/GenerateUmlOptions.cs
+++ b/src/OSK.UML.CommandLine/Commands/GenerateUmlOptions.cs
@@ -1,0 +1,29 @@
+﻿using CommandLine;
+
+namespace OSK.UML.CommandLine.Commands
+{
+    [Verb("generate", HelpText = "Generates a UML diagram based on the provided options and target.")]
+    public class GenerateUmlOptions
+    {
+        [Option('p', "path", Required = true, HelpText = "Specifies the path to a file or directory to be parsed.")]
+        public required string Path { get; set; }
+
+        [Option("fileTypes", Default = new[] { ".cs" }, HelpText = "Filter for the types of files that will be included in the uml diagram.")]
+        public required IEnumerable<string> FileTypes { get; set; }
+
+        [Option('d', "directoryDepth", Default = 1, HelpText = "How deep should the generator look for files, within a directory, when creating the UML.")]
+        public required int DirectoryDepth { get; set; }
+
+        [Option('n', "name", Default = "domainModel", HelpText = "The name of the output file that will be generated for the UML diagram.")]
+        public required string Name { get; set; }
+
+        [Option('o', "outputDirectory", Default = ".", HelpText = "Sets the output path to use for the exported uml diagram.")]
+        public required string OutputPath { get; set; }
+
+        [Option('v', "verbose", Default = false, HelpText = "Enable verbose logging.")]
+        public required bool EnableVerboseLogging { get; set; }
+
+        [Option("plantUmlPath", Default = null, HelpText = "Override the path location for the plant uml jar file that will be used to create UML diagrams.")]
+        public string? PlantUmlPathOverride { get; set; }
+    }
+}

--- a/src/OSK.UML.CommandLine/OSK.UML.CommandLine.csproj
+++ b/src/OSK.UML.CommandLine/OSK.UML.CommandLine.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<Description>Command-line tool to generate UML diagrams for a projects.</Description>
+
+		<PackAsTool>true</PackAsTool>
+		<ToolCommandName>umlgenerator</ToolCommandName>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="CommandLineParser" Version="2.9.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+		<PackageReference Include="OSK.Functions.Outputs.Logging" Version="1.4.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\OSK.UML.Exporters.PlantUML\OSK.UML.Exporters.PlantUML.csproj" />
+	  <ProjectReference Include="..\OSK.UML\OSK.UML.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.UML.CommandLine/Program.cs
+++ b/src/OSK.UML.CommandLine/Program.cs
@@ -1,0 +1,97 @@
+﻿using CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using OSK.Functions.Outputs.Abstractions;
+using OSK.Functions.Outputs.Logging;
+using OSK.Functions.Outputs.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Reflection;
+using OSK.UML;
+using OSK.UML.CommandLine.Commands;
+using OSK.UML.Exporters.PlantUML;
+
+using var cts = new CancellationTokenSource();
+int exitCode;
+var finished = false;
+
+AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+{
+    if (!finished)
+    {
+        Cancel();
+    }
+};
+Console.CancelKeyPress += (_, e) =>
+{
+    Cancel();
+    e.Cancel = true;
+};
+
+try
+{
+    var generationResult = await Parser.Default.ParseArguments<GenerateUmlOptions>(args)
+        .MapResult(
+           (GenerateUmlOptions options) =>
+           {
+               var provider = GetServiceProvider(verboseLogging: options.EnableVerboseLogging, jarFilePath: options.PlantUmlPathOverride);
+               return ActivatorUtilities.CreateInstance<GenerateUmlCommand>(provider, options)
+                .ExecuteAsync(cts.Token);
+           },
+           errs =>
+           {
+               var provider = GetServiceProvider(verboseLogging: false, jarFilePath: string.Empty);
+               var outputFactory = provider.GetRequiredService<IOutputFactory<Program>>();
+               var errors = string.Join(",", errs.Select(e => e.Tag));
+               return Task.FromResult(outputFactory.Error(HttpStatusCode.InternalServerError, $"There was an issue parsing the execution command. Errors: {errors}"));
+           });
+    if (!generationResult.IsSuccessful)
+    {
+        Console.WriteLine($"There was an error with parsing the input arguments. Error: {generationResult.GetErrorString()}");
+    }
+
+    exitCode = generationResult.IsSuccessful
+        ? 0
+        : 1;
+
+    finished = true;
+}
+catch (OperationCanceledException)
+{
+    exitCode = 2;
+}
+
+return exitCode;
+
+void Cancel()
+{
+    if (!cts.IsCancellationRequested)
+    {
+        Console.WriteLine("Cancelling...");
+        cts.Cancel();
+    }
+}
+
+IServiceProvider GetServiceProvider(bool verboseLogging, string? jarFilePath)
+{
+    var serviceCollection = new ServiceCollection();
+    serviceCollection
+        .AddUmlDiagrams()
+        .AddPlantUml(o =>
+        {
+            o.JarFilePath = jarFilePath ?? Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "plantuml-mit-1.2024.5.jar")
+             ?? throw new InvalidOperationException("No valid jar file path could be found.");
+
+            var jarPathGiven = string.IsNullOrWhiteSpace(jarFilePath)
+             ? "No jar path was provided, using the default. "
+             : string.Empty;
+            Console.WriteLine($"{jarPathGiven}Using jar path: {o.JarFilePath}");
+        })
+        .AddLogging(builder =>
+        {
+            builder.AddConsole();
+            builder.SetMinimumLevel(verboseLogging ? LogLevel.Debug : LogLevel.Information);
+        })
+        .AddLoggingFunctionOutputs();
+
+    return serviceCollection.BuildServiceProvider();
+}

--- a/src/OSK.UML.CommandLine/Properties/launchSettings.json
+++ b/src/OSK.UML.CommandLine/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "OSK.UML.CommandLine": {
+      "commandName": "Project",
+      "commandLineArgs": "-p \"C:\\Users\\M\\source\\repos\\OSK.UML\\src\\OSK.UML\\Models\" -o \"C:\\Users\\M\\Desktop\\uml\""
+    }
+  }
+}

--- a/src/OSK.UML.Exporters.PlantUML/Internal/PlantUmlConstants.cs
+++ b/src/OSK.UML.Exporters.PlantUML/Internal/PlantUmlConstants.cs
@@ -1,0 +1,19 @@
+﻿namespace OSK.UML.Exporters.PlantUML.Internal
+{
+    public static class PlantUmlConstants
+    {
+        public const string StartUml = "@startuml";
+        public const string EndUml = "@enduml";
+
+        public const string ExtensionUml_Dashed = "<|--";
+        public const string CompositionUml_Dashed = "*--";
+        public const string AggregationUml_Dashed = "o--";
+        public const string ExtensionUml_Dotted = "<|..";
+        public const string CompositionUml_Dotted = "*..";
+        public const string AggregationUml_Dotted = "o..";
+
+        public const string PrivateSymbolUml = "-";
+        public const string PublicSymbolUml = "+";
+        public const string ProtectedSymbolUml = "#";
+    }
+}

--- a/src/OSK.UML.Exporters.PlantUML/Internal/Services/PlantUmlExporter.cs
+++ b/src/OSK.UML.Exporters.PlantUML/Internal/Services/PlantUmlExporter.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OSK.Functions.Outputs.Abstractions;
+using OSK.Functions.Outputs.Logging.Abstractions;
+using OSK.UML.Exporters.PlantUML.Options;
+using OSK.UML.Exporters.PlantUML.Ports;
+using OSK.UML.Models;
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSK.UML.Exporters.PlantUML.Internal.Services
+{
+    internal class PlantUmlExporter(IOutputFactory<PlantUmlExporter> outputFactory,
+        ILogger<PlantUmlJarCommand> logger,
+        IOptions<PlantUmlOptions> options) : IPlantUmlExporter
+    {
+        #region IPlantUmlExporter
+
+        public async Task<IOutput> ExportAsync(string outputPath, UmlDiagram diagram, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(outputPath))
+            {
+                throw new ArgumentException(nameof(outputPath));
+            }
+            if (diagram == null)
+            {
+                throw new ArgumentNullException(nameof(diagram));
+            }
+
+            var umlString = ToUmlString(diagram, cancellationToken);
+            var jarCommand = new PlantUmlJarCommand(diagram.Name, umlString, outputPath, logger);
+
+            await jarCommand.ExecuteAsync(options.Value.JarFilePath, cancellationToken);
+            return outputFactory.Success();
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private string ToUmlString(UmlDiagram diagram, CancellationToken cancellationToken)
+        {
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine(PlantUmlConstants.StartUml);
+
+            foreach (var component in diagram.UmlObjects)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                WriteUmlComponent(stringBuilder, component);
+            }
+            foreach (var association in diagram.UmlAssociations)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                WriteUmlAssociation(stringBuilder, association);
+            }
+
+            stringBuilder.AppendLine(PlantUmlConstants.EndUml);
+
+            return stringBuilder.ToString();
+        }
+
+        private void WriteUmlComponent(StringBuilder builder, UmlComponent component)
+        {
+            var valueList = component as UmlValueList;
+            var construct = component as UmlConstruct;
+            var componentType = valueList == null
+                ? construct!.Type
+                : "enum";
+
+            builder.AppendLine($"{componentType} {component.Name} {{");
+
+            if (valueList != null)
+            {
+                foreach (var value in valueList.Values)
+                {
+                    builder.AppendLine(value);
+                }
+            }
+            else if (construct != null)
+            {
+                foreach (var variable in construct.Variables)
+                {
+                    builder.AppendLine($"{variable.Type} {variable.Name}");
+                }
+                foreach (var method in construct.Methods)
+                {
+                    var parameterList = string.Join(",", method.Parameters.Select(p => $"{p.Type} {p.Name}"));
+                    builder.AppendLine($"{method.Type} {method.Name}({parameterList})");
+                }
+            }
+
+            builder.AppendLine("}");
+        }
+
+        private void WriteUmlAssociation(StringBuilder builder, UmlAssociation association)
+        {
+            var uml = association.AssociationType switch
+            {
+                UmlAssociationType.Inheritance => $"{association.AssociatedObjectType} {PlantUmlConstants.ExtensionUml_Dashed} {association.Name}",
+                UmlAssociationType.Aggregation => $"{association.AssociatedObjectType} {PlantUmlConstants.AggregationUml_Dashed} {association.Name}",
+                _ => throw new InvalidOperationException($"PlantUml does not support associations of type {association.AssociationType}.")
+            };
+
+            builder.AppendLine(uml);
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.UML.Exporters.PlantUML/Internal/Services/PlantUmlJarCommand.cs
+++ b/src/OSK.UML.Exporters.PlantUML/Internal/Services/PlantUmlJarCommand.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Extensions.Logging;
+using OSK.Utilities.JarRunner;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSK.UML.Exporters.PlantUML.Internal.Services
+{
+    public sealed class PlantUmlJarCommand(string domainName, string domainModel,
+        string outputDirectory, ILogger<PlantUmlJarCommand> logger) : JarCommand<byte[]>
+    {
+        #region Variables
+
+        private string _outputFilePath = string.Empty;
+        private string _outputImagePath = string.Empty;
+
+        #endregion
+
+        #region Overrides
+
+        protected override async ValueTask<byte[]> GetResultAsync(Process process, CancellationToken cancellationToken)
+        {
+            return await File.ReadAllBytesAsync(_outputImagePath, cancellationToken);
+        }
+
+        protected override IEnumerable<string> GetArgumentList()
+        {
+            string[] arguments = ["-failfast2", "-DPLANTUML_LIMIT_SIZE=8192", _outputFilePath, $"-o {outputDirectory}"];
+            logger.LogDebug("PlantUml Arguments: {args}", string.Join(", ", arguments));
+
+            return arguments;
+        }
+
+        protected override async ValueTask PrepareAsync(CancellationToken cancellationToken = default)
+        {
+            Directory.CreateDirectory(outputDirectory);
+
+            _outputFilePath = Path.Combine(outputDirectory, $"{domainName}.txt");
+            _outputImagePath = Path.Combine(outputDirectory, $"{domainName}.png");
+
+            logger.LogDebug("Output directory: {directory}, text file path: {textFilePath}  Image Path: {imagePath}",
+                outputDirectory, _outputFilePath, _outputImagePath);
+
+            await File.WriteAllTextAsync(_outputFilePath, domainModel, cancellationToken);
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.UML.Exporters.PlantUML/OSK.UML.Exporters.PlantUML.csproj
+++ b/src/OSK.UML.Exporters.PlantUML/OSK.UML.Exporters.PlantUML.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<LangVersion>12</LangVersion>
+		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.UML</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<Description>A .NET library that provides a uml diagram exporter that is based on an integration with PlantUML.</Description>
+		<PackageTags>OpenSourceKingdom, OpenSource, OSK, parsing, uml, diagram, export, plant</PackageTags>
+		<Authors>BlankDev117</Authors>
+		<Title>OSK.UML.Exporters.PlantUML</Title>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+		<PackageReference Include="OSK.Functions.Outputs.Logging" Version="1.4.0" />
+		<PackageReference Include="OSK.Utilities.JarRunner" Version="0.0.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\OSK.UML\OSK.UML.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <None Update="plantuml-mit-1.2024.5.jar">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.UML.Exporters.PlantUML/Options/PlantUmlOptions.cs
+++ b/src/OSK.UML.Exporters.PlantUML/Options/PlantUmlOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace OSK.UML.Exporters.PlantUML.Options
+{
+    public class PlantUmlOptions
+    {
+        public string JarFilePath { get; set; }
+    }
+}

--- a/src/OSK.UML.Exporters.PlantUML/Ports/IPlantUmlExporter.cs
+++ b/src/OSK.UML.Exporters.PlantUML/Ports/IPlantUmlExporter.cs
@@ -1,0 +1,8 @@
+﻿using OSK.UML.Ports;
+
+namespace OSK.UML.Exporters.PlantUML.Ports
+{
+    public interface IPlantUmlExporter : IUmlExporter
+    {
+    }
+}

--- a/src/OSK.UML.Exporters.PlantUML/ServiceCollectionExtensions.cs
+++ b/src/OSK.UML.Exporters.PlantUML/ServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OSK.UML.Exporters.PlantUML.Internal.Services;
+using OSK.UML.Exporters.PlantUML.Options;
+using OSK.UML.Ports;
+using System;
+
+namespace OSK.UML.Exporters.PlantUML
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddPlantUml(this IServiceCollection services,
+            Action<PlantUmlOptions> configure)
+        {
+            services.TryAddTransient<IUmlExporter, PlantUmlExporter>();
+            services.Configure(configure);
+
+            return services;
+        }
+    }
+}

--- a/src/OSK.UML.Framework.UnitTests/Internal/Services/UmlInterpreterTests.cs
+++ b/src/OSK.UML.Framework.UnitTests/Internal/Services/UmlInterpreterTests.cs
@@ -1,0 +1,237 @@
+﻿using Moq;
+using OSK.Parsing.FileTokens.Models;
+using OSK.UML.Framework.Internal.Services;
+using OSK.UML.Framework.Models;
+using OSK.UML.Framework.Ports;
+using Xunit;
+
+namespace OSK.UML.Framework.UnitTests.Internal.Services
+{
+    public class UmlInterpreterTests
+    {
+        #region Variables
+
+        private readonly UmlSyntaxTemplate _syntaxTemplate;
+        private readonly Mock<IUmlDefinition> _mockDefinition;
+        private readonly IUmlInterpreter _interpreter;
+
+        #endregion
+
+        #region Constructors
+
+        public UmlInterpreterTests()
+        {
+            _syntaxTemplate = new UmlSyntaxTemplate();
+            _mockDefinition = new Mock<IUmlDefinition>();
+
+            _interpreter = new UmlInterpreter(_syntaxTemplate, _mockDefinition.Object);
+        }
+
+        #endregion
+
+        #region TotalRules
+
+        [Fact]
+        public void TotalRules_GetsValueFromTemplate()
+        {
+            // Arrrange
+            _syntaxTemplate.SetRules(SyntaxRuleType.Parameters, SyntaxRuleType.Modifiers);
+
+            // Act/Assert
+            Assert.Equal(_syntaxTemplate.Rules.Length, _interpreter.TotalRules);
+        }
+
+        #endregion
+
+        #region InterpreterType
+
+        [Fact]
+        public void InterpreterType_GetsValueFromTemplate()
+        {
+            // Arrange
+            _syntaxTemplate.ElementType = UmlElementType.Construct;
+
+            // Act/Assert
+            Assert.Equal(_syntaxTemplate.ElementType, _interpreter.InterpreterType);
+        }
+
+        #endregion
+
+        #region Reset
+
+        #endregion
+
+        #region AddFileToken
+
+        [Theory]
+        [InlineData(FileTokenType.Delimeter)]
+        [InlineData(FileTokenType.Ignore)]
+        public void AddFileToken_FileTokenCanBeIgnored_DoesNotAffectState(FileTokenType fileTokenType)
+        {
+            // Arrange/Act
+            _interpreter.AddFileToken(new FileToken(fileTokenType));
+
+            // Assert
+            Assert.Equal(UmlInterpreterState.Initialized, _interpreter.State);
+        }
+
+        [Fact]
+        public void AddFileToken_TemplateIsForMethod_FileTokenIsEndOfStatement_StateIsSetToInvalid()
+        {
+            // Arrange
+            _syntaxTemplate.ElementType = UmlElementType.Method;
+
+            // Act
+            _interpreter.AddFileToken(new FileToken(FileTokenType.EndOfStatement));
+
+            // Assert
+            Assert.Equal(UmlInterpreterState.Invalid, _interpreter.State);
+        }
+
+        [Fact]
+        public void AddFileToken_SyntaxTemplateHasNoRules_StateIsSetToInvalid()
+        {
+            // Arrange/Act
+            _interpreter.AddFileToken(new FileToken(FileTokenType.Text));
+
+            // Assert
+            Assert.Equal(UmlInterpreterState.Invalid, _interpreter.State);
+        }
+
+        [Fact]
+        public void AddFileToken_SyntaxRulesAreSatisfied_StateIsSetToSatisfied()
+        {
+            // Arrange
+            _syntaxTemplate.SetRules(SyntaxRuleType.Name);
+
+            // Act
+            _interpreter.AddFileToken(new FileToken(FileTokenType.Text, 100));
+
+            // Assert
+            Assert.Equal(UmlInterpreterState.Satisfied, _interpreter.State);
+        }
+
+        [Fact]
+        public void AddFileToken_SyntaxRulesWereSatisfiedButReadAnotherTokenThatIsInvalid_StateIsReset()
+        {
+            // Arrange
+            _syntaxTemplate.SetRules(SyntaxRuleType.Name, SyntaxRuleType.Name);
+
+            // Act
+            _interpreter.AddFileToken(new FileToken(FileTokenType.Text, 100));
+            var originalState = _interpreter.State;
+
+            _interpreter.AddFileToken(new FileToken(FileTokenType.EndOfFile));
+
+            // Assert
+            Assert.Equal(UmlInterpreterState.Parsing, originalState);
+            Assert.Equal(UmlInterpreterState.Initialized, _interpreter.State);
+        }
+
+        [Fact]
+        public void AddFileToken_FileTokenIsInvalidForOptionalRuleButSatisfiesNext_StateIsSatisfied()
+        {
+            // Arrange
+            _mockDefinition.Setup(m => m.IsModifier(It.IsAny<string>()))
+                .Returns(false);
+
+            _syntaxTemplate.SetRules(SyntaxRuleType.Modifiers, SyntaxRuleType.Name);
+
+            // Act
+            _interpreter.AddFileToken(new FileToken(FileTokenType.Text));
+
+            // Assert
+            Assert.Equal(UmlInterpreterState.Satisfied, _interpreter.State);
+        }
+
+        [Fact]
+        public void AddFileToken_FileTokenIsInvalidForOptionalRuleButIsLastRule_StateIsSatisfied()
+        {
+            // Arrange
+            _mockDefinition.Setup(m => m.IsModifier(It.IsAny<string>()))
+                .Returns(false);
+
+            _syntaxTemplate.SetRules(SyntaxRuleType.Modifiers);
+
+            // Act
+            _interpreter.AddFileToken(new FileToken(FileTokenType.Text));
+
+            // Assert
+            Assert.Equal(UmlInterpreterState.Satisfied, _interpreter.State);
+        }
+
+        #endregion
+
+        #region GetElement
+
+        [Fact]
+        public void GetElement_StateIsNotSatisfied_ReturnsNull()
+        {
+            // Arrange/Act
+            var element = _interpreter.GetElement();
+
+            // Assert
+            Assert.Null(element);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetElement_StateIsSatisfied_ReturnsExpectedElement(bool paramTypeIsFirst)
+        {
+            // Arrange
+            var modifier = "mod";
+            var visibility = "vis";
+            var name = "world";
+
+            var parameterTypeText = "name";
+            var parameterNameText = "value";
+
+            _mockDefinition.Setup(m => m.IsModifier(It.IsAny<string>()))
+                .Returns((string s) => s == modifier);
+            _mockDefinition.Setup(m => m.IsVisibility(It.IsAny<string>()))
+                .Returns((string s) => s == visibility);
+            _mockDefinition.SetupGet(m => m.MethodParameterTypeIsFirst)
+                .Returns(paramTypeIsFirst);
+
+            _syntaxTemplate.SetRules(SyntaxRuleType.Modifiers, SyntaxRuleType.Visibility,
+                SyntaxRuleType.Name, SyntaxRuleType.Parameters);
+
+            // Act
+            _interpreter.AddFileToken(new FileToken(FileTokenType.Text, modifier.Select(c => (int)c).ToArray()));
+            _interpreter.AddFileToken(new FileToken(FileTokenType.Text, visibility.Select(c => (int)c).ToArray()));
+            _interpreter.AddFileToken(new FileToken(FileTokenType.Text, name.Select(c => (int)c).ToArray()));
+
+            _interpreter.AddFileToken(new FileToken(FileTokenType.Text, parameterTypeText.Select(c => (int)c).ToArray()));
+            _interpreter.AddFileToken(new FileToken(FileTokenType.Text, parameterNameText.Select(c => (int)c).ToArray()));
+
+            _interpreter.AddFileToken(new FileToken(FileTokenType.ClosureEnd));
+
+            var element = _interpreter.GetElement();
+
+            // Assert
+            Assert.NotNull(element);
+            Assert.Equal(UmlInterpreterState.Satisfied, _interpreter.State);
+            Assert.Equal(name, element.Name);
+            Assert.Single(element.Modifiers);
+            Assert.Equal(modifier, element.Modifiers.First());
+            Assert.Equal(visibility, element.Visibility);
+            Assert.Single(element.Parameters);
+            
+            var parameter = element.Parameters.First();
+
+            if (paramTypeIsFirst)
+            {
+                Assert.Equal(parameterTypeText, parameter.Type);
+                Assert.Equal(parameterNameText, parameter.Name);
+            }
+            else
+            {
+                Assert.Equal(parameterTypeText, parameter.Name);
+                Assert.Equal(parameterNameText, parameter.Type);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.UML.Framework.UnitTests/OSK.UML.Framework.UnitTests.csproj
+++ b/src/OSK.UML.Framework.UnitTests/OSK.UML.Framework.UnitTests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+		<PackageReference Include="Moq" Version="4.20.70" />
+		<PackageReference Include="xunit" Version="2.8.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\OSK.UML.Framework\OSK.UML.Framework.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.UML.Framework/Definitions/DefaultUmlDefinition.cs
+++ b/src/OSK.UML.Framework/Definitions/DefaultUmlDefinition.cs
@@ -1,0 +1,66 @@
+﻿using OSK.UML.Framework.Models;
+
+namespace OSK.UML.Framework.Definitions
+{
+    public class DefaultUmlDefinition : UmlDefinition
+    {
+        #region Static
+
+        public static DefaultUmlDefinition Instance => new();
+
+        #endregion
+
+        public DefaultUmlDefinition()
+            : base(nameSpaceKeyWord: "namespace",
+                constructIdentifiers: [
+                    new UmlConstructIdentifier()
+                    {
+                        Name = "struct",
+                        ConstructType = UmlConstructType.Object
+                    },
+                    new UmlConstructIdentifier()
+                    {
+                        Name = "class",
+                        ConstructType = UmlConstructType.Object
+                    },
+                    new UmlConstructIdentifier()
+                    {
+                        Name = "interface",
+                        ConstructType = UmlConstructType.Object
+                    },
+                    new UmlConstructIdentifier()
+                    {
+                        Name = "enum",
+                        ConstructType = UmlConstructType.ValueList
+                    }],
+                visibilityKeyWords: [ "public", "private", "internal", "protected" ],
+                modifierKeyWords: [
+                    "abstract", "readonly", "required", "static",
+                    "record", "override", "sealed", "virtual",
+                    "unsafe", "volatile", "async", "extern" ],
+                methodParameterTypeIsFirst: true,
+                umlSyntaxTemplates: [
+                    new UmlSyntaxTemplate(SyntaxRuleType.Visibility, SyntaxRuleType.Modifiers,
+                        SyntaxRuleType.Type, SyntaxRuleType.Name, SyntaxRuleType.Parameters)
+                    {
+                        ElementType = UmlElementType.Method
+                    },
+                    new UmlSyntaxTemplate(SyntaxRuleType.Visibility, SyntaxRuleType.Modifiers,
+                        SyntaxRuleType.Type, SyntaxRuleType.Name)
+                    {
+                        ElementType = UmlElementType.Variable
+                    },
+                    new UmlSyntaxTemplate(SyntaxRuleType.Visibility, SyntaxRuleType.Modifiers,
+                        SyntaxRuleType.ConstructIdentifier, SyntaxRuleType.Name,
+                        SyntaxRuleType.Inheritance)
+                    {
+                        ElementType = UmlElementType.Construct
+                    },
+                    new UmlSyntaxTemplate(SyntaxRuleType.NameSpace, SyntaxRuleType.Name)
+                    {
+                        ElementType = UmlElementType.NameSpace
+                    }])
+        {
+        }
+    }
+}

--- a/src/OSK.UML.Framework/Definitions/UmlDefinition.cs
+++ b/src/OSK.UML.Framework/Definitions/UmlDefinition.cs
@@ -1,0 +1,74 @@
+﻿using OSK.UML.Framework.Internal.Services;
+using OSK.UML.Framework.Models;
+using OSK.UML.Framework.Ports;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OSK.UML.Framework.Definitions
+{
+    public abstract class UmlDefinition : IUmlDefinition
+    {
+        #region Variables
+
+        private readonly string _nameSpaceKeyWord;
+        private readonly bool _methodParameterTypeIsFirst;
+        private readonly IEnumerable<UmlSyntaxTemplate> _umlSyntaxTemplates;
+        private readonly Dictionary<string, UmlConstructType> _constructIdentifierLookup;
+        private readonly HashSet<string> _modifierKeyWords;
+        private readonly HashSet<string> _visibilityKeyWords;
+
+        #endregion
+
+        #region Constructors
+
+        protected UmlDefinition(
+            string nameSpaceKeyWord,
+            IEnumerable<UmlConstructIdentifier> constructIdentifiers,
+            IEnumerable<string> visibilityKeyWords,
+            IEnumerable<string> modifierKeyWords,
+            bool methodParameterTypeIsFirst,
+            IEnumerable<UmlSyntaxTemplate> umlSyntaxTemplates)
+        {
+            _nameSpaceKeyWord = nameSpaceKeyWord;
+            _constructIdentifierLookup = constructIdentifiers?.ToDictionary(c => c.Name, c => c.ConstructType) ?? throw new ArgumentNullException(nameof(constructIdentifiers));
+            _visibilityKeyWords = visibilityKeyWords?.ToHashSet() ?? throw new ArgumentNullException(nameof(visibilityKeyWords));
+            _modifierKeyWords = modifierKeyWords?.ToHashSet() ?? throw new ArgumentNullException(nameof(modifierKeyWords));
+            _methodParameterTypeIsFirst = methodParameterTypeIsFirst;
+            _umlSyntaxTemplates = umlSyntaxTemplates ?? throw new ArgumentNullException(nameof(umlSyntaxTemplates));
+        }
+
+        #endregion
+
+        #region IUmlDefinition
+
+        public IEnumerable<IUmlInterpreter> GetUmlInterpreters()
+            => _umlSyntaxTemplates.Select(t => new UmlInterpreter(t, this));
+
+        public bool MethodParameterTypeIsFirst => _methodParameterTypeIsFirst;
+
+        public bool IsNameSpace(string text)
+        {
+            return _nameSpaceKeyWord == null
+                ? false
+                : string.Equals(_nameSpaceKeyWord, text, StringComparison.Ordinal);
+        }
+
+        public bool IsVisibility(string text)
+        {
+            return _visibilityKeyWords.Contains(text);
+        }
+
+        public bool IsModifier(string text)
+        {
+            return _modifierKeyWords.Contains(text);
+        }
+
+        public bool TryGetUmlConstructType(string text, out UmlConstructType constructType)
+        {
+            return _constructIdentifierLookup.TryGetValue(text, out constructType);
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.UML.Framework/Internal/Services/UmlInterpreter.cs
+++ b/src/OSK.UML.Framework/Internal/Services/UmlInterpreter.cs
@@ -1,0 +1,206 @@
+﻿using OSK.Parsing.FileTokens.Models;
+using OSK.UML.Framework.Models;
+using OSK.UML.Framework.Ports;
+using System;
+using System.Collections.Generic;
+
+namespace OSK.UML.Framework.Internal.Services
+{
+    internal class UmlInterpreter(UmlSyntaxTemplate template, IUmlDefinition definition)
+        : IUmlInterpreter
+    {
+        #region Variables
+
+        private int _ruleIndex = 0;
+
+        private UmlInterpreterState _interpreterState = UmlInterpreterState.Initialized;
+        private string _visibility = string.Empty;
+        private string _type = string.Empty;
+        private string _name = string.Empty;
+        private List<string> _modifiers = [];
+        private List<string> _inheritance = [];
+        private List<UmlElementParameter> _parameters = [];
+        private UmlConstructType? _constructType;
+
+        private string? _firstParameterText = null;
+
+        #endregion
+
+        #region IUmlInterpreter
+
+        public int TotalRules => template.Rules.Length;
+
+        public UmlInterpreterState State => _interpreterState;
+
+        public UmlElementType InterpreterType => template.ElementType;
+
+        public void Reset()
+        {
+            _ruleIndex = 0;
+            _visibility = string.Empty;
+            _type = string.Empty;
+            _name = string.Empty;
+            _modifiers = [];
+            _inheritance = [];
+            _parameters = [];
+            _constructType = null;
+            _firstParameterText = null;
+            _interpreterState = UmlInterpreterState.Initialized;
+        }
+
+        public void AddFileToken(FileToken fileToken)
+        {
+            if ((_interpreterState != UmlInterpreterState.Initialized
+                 && _interpreterState != UmlInterpreterState.Parsing)
+                 || CanIgnoreToken(fileToken))
+            {
+                return;
+            }
+            if (template.ElementType == UmlElementType.Method &&
+                fileToken.TokenType == FileTokenType.EndOfStatement)
+            {
+                _interpreterState = UmlInterpreterState.Invalid;
+                return;
+            }
+
+            var currentRule = GetSyntaxRule(_ruleIndex);
+            if (currentRule == null)
+            {
+                _interpreterState = UmlInterpreterState.Invalid;
+                return;
+            }
+
+            var isTokenValidForRule = ValidateTokenForSyntax(fileToken, currentRule);
+            if (!isTokenValidForRule && currentRule.Optional)
+            {
+                currentRule = GetSyntaxRule(_ruleIndex + 1);
+                if (currentRule == null)
+                {
+                    _interpreterState = UmlInterpreterState.Satisfied;
+                    return;
+                }
+
+                _ruleIndex++;
+                isTokenValidForRule = ValidateTokenForSyntax(fileToken, currentRule);
+            }
+            if (!isTokenValidForRule)
+            {
+                Reset();
+                return;
+            }
+
+            SetStateForValidTokenSyntax(fileToken, currentRule);
+            _ruleIndex = currentRule.AllowMultipleTokens
+                ? _ruleIndex
+                : _ruleIndex + 1;
+
+            _interpreterState = _ruleIndex >= template.Rules.Length
+                ? UmlInterpreterState.Satisfied : UmlInterpreterState.Parsing;
+        }
+
+        public UmlElement? GetElement()
+        {
+            if (_interpreterState != UmlInterpreterState.Satisfied)
+            {
+                return null;
+            }
+
+            return new UmlElement()
+            {
+                ConstructType = _constructType,
+                UmlType = template.ElementType,
+                Name = _name,
+                Type = _type,
+                Visibility = _visibility,
+                Inheritance = _inheritance,
+                Modifiers = _modifiers,
+                Parameters = _parameters
+            };
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private bool CanIgnoreToken(FileToken fileToken)
+            => fileToken == null || fileToken.TokenType switch
+            {
+                FileTokenType.Delimeter => true,
+                FileTokenType.Ignore => true,
+                _ => false
+            };
+
+        private void SetStateForValidTokenSyntax(FileToken token, UmlSyntaxRule rule)
+        {
+            switch (rule.RuleType)
+            {
+                case SyntaxRuleType.Visibility:
+                    _visibility = token.ToString();
+                    break;
+                case SyntaxRuleType.Type:
+                    _type = token.ToString();
+                    break;
+                case SyntaxRuleType.Name:
+                    _name = token.ToString();
+                    break;
+                case SyntaxRuleType.ConstructIdentifier:
+                    var tokenString = token.ToString();
+                    if (definition.TryGetUmlConstructType(tokenString, out var identifier))
+                    {
+                        _type = tokenString;
+                        _constructType = identifier;
+                    }
+                    break;
+                case SyntaxRuleType.Modifiers:
+                    _modifiers.Add(token.ToString());
+                    break;
+                case SyntaxRuleType.Inheritance:
+                    _inheritance.Add(token.ToString());
+                    break;
+                case SyntaxRuleType.Parameters:
+                    if (token.TokenType == FileTokenType.ClosureStart)
+                    {
+                        return;
+                    }
+                    if (_firstParameterText == null)
+                    {
+                        _firstParameterText = token.ToString();
+                    }
+                    else
+                    {
+                        _parameters.Add(new UmlElementParameter()
+                        {
+                            Name = definition.MethodParameterTypeIsFirst ? token.ToString() : _firstParameterText,
+                            Type = definition.MethodParameterTypeIsFirst ? _firstParameterText : token.ToString(),
+                        });
+                        _firstParameterText = null;
+                    }
+                    break;
+            }
+        }
+
+        private bool ValidateTokenForSyntax(FileToken fileToken, UmlSyntaxRule syntaxRule)
+        {
+            var matchesRule = syntaxRule.RuleType switch
+            {
+                SyntaxRuleType.NameSpace => fileToken.TokenType == FileTokenType.Text && definition.IsNameSpace(fileToken.ToString()),
+                SyntaxRuleType.Parameters => fileToken.TokenType == FileTokenType.ClosureStart || fileToken.TokenType == FileTokenType.Text,
+                SyntaxRuleType.Type => fileToken.TokenType == FileTokenType.Text,
+                SyntaxRuleType.Name => fileToken.TokenType == FileTokenType.Text,
+                SyntaxRuleType.Inheritance => fileToken.TokenType == FileTokenType.Text,
+                SyntaxRuleType.Modifiers => definition.IsModifier(fileToken.ToString()),
+                SyntaxRuleType.Visibility => definition.IsVisibility(fileToken.ToString()),
+                SyntaxRuleType.ConstructIdentifier => definition.TryGetUmlConstructType(fileToken.ToString(), out _),
+                _ => throw new InvalidOperationException($"Unexpected rule type was used: {syntaxRule.RuleType}.")
+            };
+
+            return matchesRule;
+        }
+
+        private UmlSyntaxRule? GetSyntaxRule(int index)
+            => index >= template.Rules.Length
+             ? null : template.Rules[index];
+
+        #endregion
+    }
+}

--- a/src/OSK.UML.Framework/Models/SyntaxRuleType.cs
+++ b/src/OSK.UML.Framework/Models/SyntaxRuleType.cs
@@ -1,0 +1,14 @@
+﻿namespace OSK.UML.Framework.Models
+{
+    public enum SyntaxRuleType
+    {
+        NameSpace,
+        Visibility,
+        Modifiers,
+        Type,
+        Name,
+        Parameters,
+        ConstructIdentifier,
+        Inheritance
+    }
+}

--- a/src/OSK.UML.Framework/Models/UmlConstructIdentifier.cs
+++ b/src/OSK.UML.Framework/Models/UmlConstructIdentifier.cs
@@ -1,0 +1,15 @@
+﻿namespace OSK.UML.Framework.Models
+{
+    public class UmlConstructIdentifier
+    {
+        internal static UmlConstructIdentifier None = new UmlConstructIdentifier()
+        {
+            ConstructType = UmlConstructType.Object,
+            Name = string.Empty
+        };
+
+        public string Name { get; set; }
+
+        public UmlConstructType ConstructType { get; set; }
+    }
+}

--- a/src/OSK.UML.Framework/Models/UmlConstructType.cs
+++ b/src/OSK.UML.Framework/Models/UmlConstructType.cs
@@ -1,0 +1,14 @@
+﻿namespace OSK.UML.Framework.Models
+{
+    public enum UmlConstructType
+    {
+        /// <summary>
+        /// An object within some file based on user configuration. This is able to hold information relating to <see cref="UmlElementType.Method"/> and <see cref="UmlElementType.Variable"/>.
+        /// </summary>
+        Object,
+        /// <summary>
+        /// A list of string deliminated values based on user configuration. This closely matches what an enum would be in C#.
+        /// </summary>
+        ValueList
+    }
+}

--- a/src/OSK.UML.Framework/Models/UmlElement.cs
+++ b/src/OSK.UML.Framework/Models/UmlElement.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace OSK.UML.Framework.Models
+{
+    public class UmlElement
+    {
+        public string Name { get; set; }
+
+        public UmlElementType UmlType { get; set; }
+
+        public string Type { get; set; }
+
+        public string Visibility { get; set; }
+
+        public IEnumerable<string> Inheritance { get; set; }
+
+        public IEnumerable<string> Modifiers { get; set; }
+
+        public UmlConstructType? ConstructType { get; set; }
+
+        public IEnumerable<UmlElementParameter> Parameters { get; set; }
+    }
+}

--- a/src/OSK.UML.Framework/Models/UmlElementParameter.cs
+++ b/src/OSK.UML.Framework/Models/UmlElementParameter.cs
@@ -1,0 +1,9 @@
+﻿namespace OSK.UML.Framework.Models
+{
+    public class UmlElementParameter
+    {
+        public string Type { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/src/OSK.UML.Framework/Models/UmlElementType.cs
+++ b/src/OSK.UML.Framework/Models/UmlElementType.cs
@@ -1,0 +1,22 @@
+﻿namespace OSK.UML.Framework.Models
+{
+    public enum UmlElementType
+    {
+        /// <summary>
+        /// A function body within a <see cref="UmlConstructType.Object"/>
+        /// </summary>
+        Method,
+        /// <summary>
+        /// A property or field within a <see cref="UmlConstructType.Object"/>
+        /// </summary>
+        Variable,
+        /// <summary>
+        /// An object of some kind within <see cref="UmlConstructType"/>
+        /// </summary>
+        Construct,
+        /// <summary>
+        /// The namespace for other elements that are being interpreted within the same scope
+        /// </summary>
+        NameSpace
+    }
+}

--- a/src/OSK.UML.Framework/Models/UmlInterpreterState.cs
+++ b/src/OSK.UML.Framework/Models/UmlInterpreterState.cs
@@ -1,0 +1,22 @@
+﻿namespace OSK.UML.Framework.Models
+{
+    public enum UmlInterpreterState
+    {
+        /// <summary>
+        /// Signifies that the inerpeter has not yet received input for state information to be determined
+        /// </summary>
+        Initialized,
+        /// <summary>
+        /// The current state of the interpreter is in a bad state and a valid <see cref="UmlElement"/> can not be created from the current state.
+        /// </summary>
+        Invalid,
+        /// <summary>
+        /// The interpreter is currently parsing state information and a determination for whether a <see cref="UmlElement"/> can be created has yet to be made and more input is reqired to do so.
+        /// </summary>
+        Parsing,
+        /// <summary>
+        /// The interpreter is able to create a valid <see cref="UmlElement"/> based on the currnet information that has been provided. Further input while in this state could potentially invalidate the element and should be retrieved and the interpreter reset prior to reading more data.
+        /// </summary>
+        Satisfied
+    }
+}

--- a/src/OSK.UML.Framework/Models/UmlSyntaxRule.cs
+++ b/src/OSK.UML.Framework/Models/UmlSyntaxRule.cs
@@ -1,0 +1,11 @@
+﻿namespace OSK.UML.Framework.Models
+{
+    public class UmlSyntaxRule
+    {
+        public SyntaxRuleType RuleType { get; set; }
+
+        public bool AllowMultipleTokens { get; set; }
+
+        public bool Optional { get; set; }
+    }
+}

--- a/src/OSK.UML.Framework/Models/UmlSyntaxTemplate.cs
+++ b/src/OSK.UML.Framework/Models/UmlSyntaxTemplate.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+
+namespace OSK.UML.Framework.Models
+{
+    public class UmlSyntaxTemplate
+    {
+        public UmlElementType ElementType { get; set; }
+
+        public UmlSyntaxRule[] Rules { get; private set; }
+
+        public UmlSyntaxTemplate()
+        {
+            Rules = Array.Empty<UmlSyntaxRule>();
+        }
+
+        public UmlSyntaxTemplate(params UmlSyntaxRule[] syntaxRules)
+        {
+            Rules = syntaxRules;
+        }
+
+        public UmlSyntaxTemplate(params SyntaxRuleType[] ruleTypes)
+        {
+            SetRules(ruleTypes);
+            if (Rules == null)
+            {
+                throw new ArgumentNullException(nameof(ruleTypes));
+            }
+        }
+
+        internal void SetRules(params SyntaxRuleType[] ruleTypes)
+        {
+            Rules = ruleTypes.Select(ruleType => new UmlSyntaxRule()
+            {
+                RuleType = ruleType,
+                AllowMultipleTokens = ruleType == SyntaxRuleType.Modifiers
+                 || ruleType == SyntaxRuleType.Parameters
+                 || ruleType == SyntaxRuleType.Inheritance,
+                Optional = ruleType == SyntaxRuleType.Modifiers
+                 || ruleType == SyntaxRuleType.Parameters
+                 || ruleType == SyntaxRuleType.Inheritance
+            }).ToArray();
+        }
+
+        internal void SetRules(params UmlSyntaxRule[] rules)
+        {
+            Rules = rules;
+        }
+    }
+}

--- a/src/OSK.UML.Framework/OSK.UML.Framework.csproj
+++ b/src/OSK.UML.Framework/OSK.UML.Framework.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<Nullable>enable</Nullable>
+		<LangVersion>12</LangVersion>
+		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.UML</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<Description>A .NET library that provides a foundational framework for parsing files or directories into UML diagrams.</Description>
+		<PackageTags>OpenSourceKingdom, OpenSource, OSK, parsing, file, directory, reader, parse, uml, diagram, framework</PackageTags>
+		<Authors>BlankDev117</Authors>
+		<Title>OSK.UML.Framework</Title>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="OSK.Parsing.FileTokens" Version="0.0.4" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.UML.Framework/Ports/IUmlDefinition.cs
+++ b/src/OSK.UML.Framework/Ports/IUmlDefinition.cs
@@ -1,0 +1,16 @@
+﻿using OSK.UML.Framework.Models;
+using System.Collections.Generic;
+
+namespace OSK.UML.Framework.Ports
+{
+    public interface IUmlDefinition
+    {
+        IEnumerable<IUmlInterpreter> GetUmlInterpreters();
+        bool MethodParameterTypeIsFirst { get; }
+
+        bool IsNameSpace(string text);
+        bool IsVisibility(string text);
+        bool IsModifier(string text);
+        bool TryGetUmlConstructType(string text, out UmlConstructType constructType);
+    }
+}

--- a/src/OSK.UML.Framework/Ports/IUmlInterpreter.cs
+++ b/src/OSK.UML.Framework/Ports/IUmlInterpreter.cs
@@ -1,0 +1,20 @@
+﻿using OSK.Parsing.FileTokens.Models;
+using OSK.UML.Framework.Models;
+
+namespace OSK.UML.Framework.Ports
+{
+    public interface IUmlInterpreter
+    {
+        int TotalRules { get; }
+
+        UmlElementType InterpreterType { get; }
+
+        UmlInterpreterState State { get; }
+
+        void Reset();
+
+        void AddFileToken(FileToken fileToken);
+
+        UmlElement? GetElement();
+    }
+}

--- a/src/OSK.UML.Framework/Properties/Assembly.cs
+++ b/src/OSK.UML.Framework/Properties/Assembly.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OSK.UML.Framework.UnitTests")]

--- a/src/OSK.UML.Framework/Properties/launchSettings.json
+++ b/src/OSK.UML.Framework/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "OSK.UML.Framework": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/src/OSK.UML.UnitTests/Internal/Services/DefaultUmlGeneratorTests.cs
+++ b/src/OSK.UML.UnitTests/Internal/Services/DefaultUmlGeneratorTests.cs
@@ -1,0 +1,218 @@
+﻿using Moq;
+using OSK.Functions.Outputs.Logging.Abstractions;
+using OSK.Functions.Outputs.Mocks;
+using OSK.Parsing.FileTokens.Ports;
+using OSK.UML.Internal.Services;
+using OSK.UML.Models;
+using OSK.UML.Options;
+using OSK.UML.Ports;
+using System.Net;
+using Xunit;
+
+namespace OSK.UML.UnitTests.Internal.Services
+{
+    public class DefaultUmlGeneratorTests: IDisposable
+    {
+        #region Variables
+
+        private string _testDirectory;
+
+        private readonly Mock<IUmlParser> _mockParser;
+        private readonly IOutputFactory<DefaultUmlGenerator> _outputFactory;
+        private readonly IUmlGenerator _generator;
+
+        #endregion
+
+        #region Constructors
+
+        public DefaultUmlGeneratorTests() 
+        {
+            _testDirectory = Path.Combine(".", "TestData");
+            Directory.CreateDirectory(_testDirectory);
+
+            _mockParser = new Mock<IUmlParser>();
+
+            var mockParserFactory = new Mock<IUmlParserFactory>();
+            mockParserFactory.Setup(m => m.CreateParser(It.IsAny<string>(), It.IsAny<ITokenStateHandler>()))
+                .Returns(_mockParser.Object);
+
+            _outputFactory = new MockOutputFactory<DefaultUmlGenerator>();
+            _generator = new DefaultUmlGenerator(mockParserFactory.Object, _outputFactory);
+        }
+
+        #endregion
+
+        #region Disposable
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_testDirectory))
+            {
+                Directory.Delete(_testDirectory, true);
+            }
+
+            Assert.False(Directory.Exists(_testDirectory));
+        }
+
+        #endregion
+
+        #region GenerateUmlAsync
+
+        [Fact]
+        public async Task GenerateUmlAsync_NullPath_ThrowsArgumentException()
+        {
+            // Arrange/Act/Assert
+            await Assert.ThrowsAsync<ArgumentException>(async () => await _generator.GenerateUmlAsync(null, "Hi", new UmlGenerationOptions()));
+        }
+
+        [Fact]
+        public async Task GenerateUmlAsync_NullDomainName_ThrowsArgumentException()
+        {
+            // Arrange/Act/Assert
+            await Assert.ThrowsAsync<ArgumentException>(async () => await _generator.GenerateUmlAsync("Hi", null, new UmlGenerationOptions()));
+        }
+
+        [Fact]
+        public async Task GenerateUmlAsync_ParserReturnsNull_ReturnsBadRequest()
+        {
+            // Arrange
+            var path = Path.Combine(_testDirectory, "test");
+            using var _ = File.CreateText(path);
+
+            _mockParser.Setup(m => m.ParseUmlAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IEnumerable<UmlComponent>)null!);
+
+            // Act
+            var result = await _generator.GenerateUmlAsync(path, "hi", new UmlGenerationOptions());
+
+            // Assert
+            Assert.False(result.IsSuccessful);
+            Assert.Equal(HttpStatusCode.BadRequest, result.Code.StatusCode);
+        }
+
+        [Fact]
+        public async Task GenerateUmlAsync_PathNotFound_ReturnsNotFound()
+        {
+            // Arrange/Act
+            var result = await _generator.GenerateUmlAsync("notreal", "hi", new UmlGenerationOptions());
+
+            // Assert
+            Assert.False(result.IsSuccessful);
+            Assert.Equal(HttpStatusCode.NotFound, result.Code.StatusCode);
+        }
+
+        [Fact]
+        public async Task GenerateUmlAsync_PathForSingleFile_ParserReturnsSuccessfully_ReturnsExpectedList()
+        {
+            // Arrange
+            var path = Path.Combine(_testDirectory, "test");
+            using var _ = File.CreateText(path);
+
+            List<UmlComponent> expectedComponents = [ new UmlConstruct() { Name = "hi" }, new UmlValueList() { Name = "two" } ];
+            _mockParser.Setup(m => m.ParseUmlAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedComponents);
+
+            // Act
+            var result = await _generator.GenerateUmlAsync(path, "hi", new UmlGenerationOptions());
+
+            // Assert
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("hi", result.Value.UmlDiagram.Name);
+            Assert.Equal(expectedComponents, result.Value.UmlDiagram.UmlObjects);
+        }
+
+        [Fact]
+        public async Task GenerateUmlAsync_PathForDirectory_FilterForCSharpFiles_ParserReturnsSuccessfully_ReturnsExpectedList()
+        {
+            // Arrange
+            var testFiles = 3;
+            for (var i = 0; i < testFiles; i++)
+            {
+                var path = Path.Combine(_testDirectory, $"test{i}.cs");
+                using var _ = File.CreateText(path);
+            }
+
+            List<UmlComponent> expectedComponents = [
+                new UmlConstruct() { Name = "hi" }, new UmlValueList() { Name = "two" },
+                new UmlConstruct() { Name = "hello" },
+                new UmlValueList() { Name = "twoFor" }, new UmlValueList() { Name = "twoHelp" }
+            ];
+            var returnCount = 0;
+            _mockParser.Setup(m => m.ParseUmlAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    if (returnCount == 0)
+                    {
+                        returnCount++;
+                        return expectedComponents.Take(2);
+                    }
+                    if (returnCount == 1)
+                    {
+                        returnCount++;
+                        return expectedComponents.Skip(2).Take(1);
+                    }
+
+                    return expectedComponents.Skip(3);
+                });
+
+            // Act
+            var result = await _generator.GenerateUmlAsync(_testDirectory, "hi", new UmlGenerationOptions());
+
+            // Assert
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("hi", result.Value.UmlDiagram.Name);
+            Assert.Equal(expectedComponents, result.Value.UmlDiagram.UmlObjects);
+        }
+
+        [Fact]
+        public async Task GenerateUmlAsync_PathForDirectory_FilterForAllFiles_ParserReturnsSuccessfully_ReturnsExpectedList()
+        {
+            // Arrange
+            var testFiles = 3;
+            for (var i = 0; i < testFiles; i++)
+            {
+                var extension = i == 0 ? ".cs"
+                    : i == 1 ? ".txt"
+                    : string.Empty;
+                var path = Path.Combine(_testDirectory, $"test{i}{extension}");
+                using var _ = File.CreateText(path);
+            }
+
+            List<UmlComponent> expectedComponents = [
+                new UmlConstruct() { Name = "hi" }, new UmlValueList() { Name = "two" },
+                new UmlConstruct() { Name = "hello" },
+                new UmlValueList() { Name = "twoFor" }, new UmlValueList() { Name = "twoHelp" }
+            ];
+            var returnCount = 0;
+            _mockParser.Setup(m => m.ParseUmlAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    if (returnCount == 0)
+                    {
+                        returnCount++;
+                        return expectedComponents.Take(2);
+                    }
+                    if (returnCount == 1)
+                    {
+                        returnCount++;
+                        return expectedComponents.Skip(2).Take(1);
+                    }
+
+                    return expectedComponents.Skip(3);
+                });
+
+            // Act
+            var result = await _generator.GenerateUmlAsync(_testDirectory, "hi", new UmlGenerationOptions()
+            {
+                FileExtensionPattern = string.Empty
+            });
+
+            // Assert
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("hi", result.Value.UmlDiagram.Name);
+            Assert.Equal(expectedComponents, result.Value.UmlDiagram.UmlObjects);
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.UML.UnitTests/Internal/Services/UmlParserTests.cs
+++ b/src/OSK.UML.UnitTests/Internal/Services/UmlParserTests.cs
@@ -1,0 +1,252 @@
+﻿using Moq;
+using OSK.Parsing.FileTokens.Models;
+using OSK.Parsing.FileTokens.Ports;
+using OSK.UML.Framework.Models;
+using OSK.UML.Framework.Ports;
+using OSK.UML.Internal.Services;
+using OSK.UML.Models;
+using OSK.UML.Ports;
+using Xunit;
+
+namespace OSK.UML.UnitTests.Internal.Services
+{
+    public class UmlParserTests
+    {
+        #region Variables
+
+        private readonly IList<IUmlInterpreter> _interpreterList;
+
+        private readonly Mock<IFileTokenReader> _mockTokenReader;
+        private readonly IUmlParser _umlParser;
+
+        #endregion
+
+        #region Constructors
+
+        public UmlParserTests()
+        {
+            _interpreterList = new List<IUmlInterpreter>();
+
+            _mockTokenReader = new Mock<IFileTokenReader>();
+            var mockDefinition = new Mock<IUmlDefinition>();
+            mockDefinition.Setup(m => m.GetUmlInterpreters())
+                .Returns(_interpreterList);
+
+            _umlParser = new UmlParser(_mockTokenReader.Object, mockDefinition.Object);
+        }
+
+        #endregion
+
+        #region ParseUmlAsync
+
+        [Fact]
+        public async Task ParseUmlAsync_FileTokenReaderReturnsEndOfFile_ReturnsEmptyList()
+        {
+            // Arrange
+            _mockTokenReader.Setup(m => m.ReadTokenAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new FileToken(FileTokenType.EndOfFile));
+
+            // Act
+            var components = await _umlParser.ParseUmlAsync();
+
+            // Assert
+            Assert.Empty(components);
+        }
+
+        [Theory]
+        [InlineData(FileTokenType.EndOfFile)]
+        [InlineData(FileTokenType.ClosureEnd)]
+        public async Task ParseUmlAsync_ValueListAndNameSpaceInterpretersSatisfied_DifferentEndTokensUsed_ReturnsExpectedUmlComponent(FileTokenType endFileTokenType)
+        {
+            // Arrange
+            var nameSpace = "helloWorld";
+            var enumName = "AbcEnum";
+            var expectedValues = new[] { "Abc", "dEF", "hIj" };
+
+            var mockNameSpaceInterpreter = new Mock<IUmlInterpreter>();
+            mockNameSpaceInterpreter.SetupGet(m => m.InterpreterType)
+                .Returns(UmlElementType.NameSpace);
+            mockNameSpaceInterpreter.SetupGet(m => m.State)
+                .Returns(UmlInterpreterState.Satisfied);
+            mockNameSpaceInterpreter.Setup(m => m.GetElement())
+                .Returns(new UmlElement()
+                {
+                    Name = nameSpace
+                });
+
+            _interpreterList.Add(mockNameSpaceInterpreter.Object);
+
+            var mockValueListInterpreter = new Mock<IUmlInterpreter>();
+            mockValueListInterpreter.SetupGet(m => m.InterpreterType)
+                .Returns(UmlElementType.Construct);
+            mockValueListInterpreter.SetupGet(m => m.State)
+                .Returns(UmlInterpreterState.Satisfied);
+            mockValueListInterpreter.Setup(m => m.GetElement())
+                .Returns(new UmlElement()
+                {
+                    ConstructType = UmlConstructType.ValueList,
+                    Name = enumName
+                });
+
+            _interpreterList.Add(mockValueListInterpreter.Object);
+
+            var i = 0;
+            var endTokenReached = false;
+            _mockTokenReader.Setup(m => m.ReadTokenAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    if (endTokenReached)
+                    {
+                        return new FileToken(FileTokenType.EndOfFile);
+                    }
+
+                    var token = i < 2
+                     ? new FileToken(FileTokenType.Text, nameSpace.Select(c => (int)c).ToArray())
+                     : i - 2 >= expectedValues.Length
+                       ? new FileToken(endFileTokenType)
+                       : new FileToken(FileTokenType.Text, expectedValues[i - 2].Select(c => (int)c).ToArray());
+
+                    i++;
+                    if (token.TokenType == endFileTokenType)
+                    {
+                        endTokenReached = true;
+                    }
+
+                    return token;
+                });
+
+            // Act
+            var components = await _umlParser.ParseUmlAsync();
+
+            // Assert
+            Assert.Single(components);
+
+            var element = (UmlValueList) components.First();
+
+            Assert.Equal(nameSpace, element.Namespace);
+            Assert.Equal(enumName, element.Name);
+            Assert.Equal(expectedValues, element.Values);
+        }
+
+        [Fact]
+        public async Task ParseUmlAsync_ObjectWithoutNameSpaceSatsified_ReturnsExpectedUmlComponent()
+        {
+            var objectName = "AbcObject";
+            var visibility = "whatAWorld";
+            var expectedModifiers = new[] { "Abc", "dEF", "hIj" };
+            var expectedInheritance = new[] { "super" };
+
+            var mockObjectInterpreter = new Mock<IUmlInterpreter>();
+            mockObjectInterpreter.SetupGet(m => m.InterpreterType)
+                .Returns(UmlElementType.Construct);
+            mockObjectInterpreter.SetupGet(m => m.State)
+                .Returns(UmlInterpreterState.Satisfied);
+            mockObjectInterpreter.Setup(m => m.GetElement())
+                .Returns(new UmlElement()
+                {
+                    Visibility = visibility,
+                    Modifiers = expectedModifiers,
+                    Inheritance = expectedInheritance,
+                    ConstructType = UmlConstructType.Object,
+                    Name = objectName
+                });
+
+            _interpreterList.Add(mockObjectInterpreter.Object);
+
+            var mockMemberInterpreter = new Mock<IUmlInterpreter>();
+            mockMemberInterpreter.SetupGet(m => m.InterpreterType)
+                .Returns(UmlElementType.Method);
+            mockMemberInterpreter.SetupGet(m => m.State)
+                .Returns(UmlInterpreterState.Satisfied);
+
+            var methodElement = new UmlElement()
+            {
+                Name = "Method",
+                UmlType = UmlElementType.Method,
+                Parameters = [
+                    new UmlElementParameter()
+                    {
+                        Name = "Hi",
+                        Type = "two"
+                    }
+                ],
+                Visibility = "cotton",
+                Type = "Fields",
+                Modifiers = [ "WorldBest" ]
+            };
+            var variableElement = new UmlElement()
+            {
+                Name = "Variable",
+                UmlType = UmlElementType.Variable,
+                Modifiers = [ "CottonWood" ],
+                Type = "woops"
+            };
+            var returningMemberIndex = 0;
+            mockMemberInterpreter.Setup(m => m.GetElement())
+                .Returns(() =>
+                {
+                    var element = returningMemberIndex == 0
+                        ? methodElement
+                        : variableElement;
+
+                    returningMemberIndex++;
+                    return element;
+                });
+
+            _interpreterList.Add(mockMemberInterpreter.Object);
+
+            var memberIndex = 0;
+            _mockTokenReader.Setup(m => m.ReadTokenAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    if (memberIndex < 3)
+                    {
+                        memberIndex++;
+                        return new FileToken(FileTokenType.Text);
+                    }
+
+                    var token = memberIndex == 3
+                        ? new FileToken(FileTokenType.Assignment)
+                        : new FileToken(FileTokenType.EndOfFile);
+                    memberIndex++;
+
+                    return token;
+                });
+
+            // Act
+            var result = await _umlParser.ParseUmlAsync();
+
+            // Assert
+            Assert.Single(result);
+
+            var umlObject = (UmlConstruct)result.First();
+
+            Assert.Equal(objectName, umlObject.Name);
+            Assert.Equal(expectedModifiers, umlObject.Modifiers);
+            Assert.Equal(expectedInheritance, umlObject.Inheritance);
+            Assert.Equal(visibility, umlObject.Visibility);
+            Assert.Null(umlObject.Namespace);
+
+            Assert.Single(umlObject.Variables);
+            var variable = umlObject.Variables.First();
+            
+            Assert.Equal(variableElement.Name, variable.Name);
+            Assert.Equal(variableElement.Type, variable.Type);
+            Assert.Equal(variable.Visibility, variable.Visibility);
+            Assert.Equal(variableElement.Modifiers, variable.Modifiers);
+
+            Assert.Single(umlObject.Methods);
+            var method = umlObject.Methods.First();
+
+            Assert.Equal(methodElement.Name, method.Name);
+            Assert.Equal(methodElement.Type, method.Type);
+            Assert.Equal(methodElement.Visibility, method.Visibility);
+            Assert.Equal(methodElement.Modifiers, method.Modifiers);
+
+            _mockTokenReader.Verify(m => m.ReadToEndTokenAsync(It.IsAny<FileToken>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.UML.UnitTests/OSK.UML.UnitTests.csproj
+++ b/src/OSK.UML.UnitTests/OSK.UML.UnitTests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+		<PackageReference Include="Moq" Version="4.20.70" />
+		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="1.4.0" />
+		<PackageReference Include="xunit" Version="2.8.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\OSK.UML\OSK.UML.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.UML.sln
+++ b/src/OSK.UML.sln
@@ -1,0 +1,61 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.UML", "OSK.UML\OSK.UML.csproj", "{C30678A6-313F-4131-8098-7BB9E450707A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.UML.Exporters.PlantUML", "OSK.UML.Exporters.PlantUML\OSK.UML.Exporters.PlantUML.csproj", "{E59A6251-C0B5-43B0-9A8A-703348561C11}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.UML.CommandLine", "OSK.UML.CommandLine\OSK.UML.CommandLine.csproj", "{AAFD02E9-8B5E-47FE-94E4-CF793CB2E79D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.UML.Framework", "OSK.UML.Framework\OSK.UML.Framework.csproj", "{ECB6D2F4-96CB-4BAE-843E-B75A0FA256E4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSK.UML.Framework.UnitTests", "OSK.UML.Framework.UnitTests\OSK.UML.Framework.UnitTests.csproj", "{D25AA9AF-3391-46D5-B56B-A17C627DB620}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSK.UML.UnitTests", "OSK.UML.UnitTests\OSK.UML.UnitTests.csproj", "{FAD15D13-6F30-46D6-82AF-8D2C19AC99CE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.Parsing.FileTokens", "..\..\OSK.Parsing.FileTokens\src\OSK.Parsing.FileTokens\OSK.Parsing.FileTokens.csproj", "{C1DBBEF1-2259-4DBC-875D-7639908708E8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C30678A6-313F-4131-8098-7BB9E450707A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C30678A6-313F-4131-8098-7BB9E450707A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C30678A6-313F-4131-8098-7BB9E450707A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C30678A6-313F-4131-8098-7BB9E450707A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E59A6251-C0B5-43B0-9A8A-703348561C11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E59A6251-C0B5-43B0-9A8A-703348561C11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E59A6251-C0B5-43B0-9A8A-703348561C11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E59A6251-C0B5-43B0-9A8A-703348561C11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAFD02E9-8B5E-47FE-94E4-CF793CB2E79D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAFD02E9-8B5E-47FE-94E4-CF793CB2E79D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAFD02E9-8B5E-47FE-94E4-CF793CB2E79D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAFD02E9-8B5E-47FE-94E4-CF793CB2E79D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ECB6D2F4-96CB-4BAE-843E-B75A0FA256E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ECB6D2F4-96CB-4BAE-843E-B75A0FA256E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ECB6D2F4-96CB-4BAE-843E-B75A0FA256E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ECB6D2F4-96CB-4BAE-843E-B75A0FA256E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D25AA9AF-3391-46D5-B56B-A17C627DB620}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D25AA9AF-3391-46D5-B56B-A17C627DB620}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D25AA9AF-3391-46D5-B56B-A17C627DB620}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D25AA9AF-3391-46D5-B56B-A17C627DB620}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAD15D13-6F30-46D6-82AF-8D2C19AC99CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAD15D13-6F30-46D6-82AF-8D2C19AC99CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAD15D13-6F30-46D6-82AF-8D2C19AC99CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAD15D13-6F30-46D6-82AF-8D2C19AC99CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1DBBEF1-2259-4DBC-875D-7639908708E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1DBBEF1-2259-4DBC-875D-7639908708E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1DBBEF1-2259-4DBC-875D-7639908708E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1DBBEF1-2259-4DBC-875D-7639908708E8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5DBC810E-632B-4914-851F-1FED2354A3DF}
+	EndGlobalSection
+EndGlobal

--- a/src/OSK.UML.sln
+++ b/src/OSK.UML.sln
@@ -15,8 +15,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSK.UML.Framework.UnitTests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSK.UML.UnitTests", "OSK.UML.UnitTests\OSK.UML.UnitTests.csproj", "{FAD15D13-6F30-46D6-82AF-8D2C19AC99CE}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.Parsing.FileTokens", "..\..\OSK.Parsing.FileTokens\src\OSK.Parsing.FileTokens\OSK.Parsing.FileTokens.csproj", "{C1DBBEF1-2259-4DBC-875D-7639908708E8}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,10 +45,6 @@ Global
 		{FAD15D13-6F30-46D6-82AF-8D2C19AC99CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FAD15D13-6F30-46D6-82AF-8D2C19AC99CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FAD15D13-6F30-46D6-82AF-8D2C19AC99CE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C1DBBEF1-2259-4DBC-875D-7639908708E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C1DBBEF1-2259-4DBC-875D-7639908708E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C1DBBEF1-2259-4DBC-875D-7639908708E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C1DBBEF1-2259-4DBC-875D-7639908708E8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/OSK.UML/Internal/Services/DefaultUmlGenerator.cs
+++ b/src/OSK.UML/Internal/Services/DefaultUmlGenerator.cs
@@ -1,0 +1,152 @@
+﻿using OSK.Functions.Outputs.Abstractions;
+using OSK.Functions.Outputs.Logging.Abstractions;
+using OSK.Parsing.FileTokens.Handlers;
+using OSK.UML.Models;
+using OSK.UML.Options;
+using OSK.UML.Ports;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSK.UML.Internal.Services
+{
+    internal class DefaultUmlGenerator(IUmlParserFactory umlParserFactory,
+        IOutputFactory<DefaultUmlGenerator> outputFactory) : IUmlGenerator
+    {
+        #region IUmlGenerator
+
+        public async Task<IOutput<UmlGenerationResult>> GenerateUmlAsync(string path, string domainName, UmlGenerationOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException(nameof(path));
+            }
+            if (string.IsNullOrWhiteSpace(domainName))
+            {
+                throw new ArgumentException(nameof(domainName));
+            }
+
+            var isDirectory = Directory.Exists(path);
+            if (isDirectory)
+            {
+                var parseDirectoryResult = await ParseDirectoryAsync(path, options, cancellationToken);
+                return parseDirectoryResult.IsSuccessful ? outputFactory.Success(new UmlGenerationResult()
+                {
+                    TotalUmlObjectsDiscovered = parseDirectoryResult.Value.Item1.Count(),
+                    TotalFilesChecked = parseDirectoryResult.Value.Item2,
+                    UmlDiagram = new UmlDiagram()
+                    {
+                        Name = domainName,
+                        UmlObjects = parseDirectoryResult.Value.Item1,
+                        UmlAssociations = GetAssociations(parseDirectoryResult.Value.Item1)
+                    }
+                }) : parseDirectoryResult.AsType<UmlGenerationResult>();
+            }
+
+            var isFile = File.Exists(path);
+            if (isFile)
+            {
+                var parseFileResult = await ParseFileAsync(path, cancellationToken);
+                return parseFileResult.IsSuccessful ? outputFactory.Success(new UmlGenerationResult()
+                {
+                    TotalFilesChecked = 1,
+                    TotalUmlObjectsDiscovered = parseFileResult.Value.Count(),
+                    UmlDiagram = new UmlDiagram()
+                    {
+                        Name = domainName,
+                        UmlObjects = parseFileResult.Value,
+                        UmlAssociations = GetAssociations(parseFileResult.Value)
+                    }
+                }) : parseFileResult.AsType<UmlGenerationResult>();
+            }
+
+            return outputFactory.Error<UmlGenerationResult>(HttpStatusCode.NotFound, $"The path {path} was not a valid path to a file or directory",
+                "OSK.UML");
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private async Task<IOutput<Tuple<IEnumerable<UmlComponent>, int>>> ParseDirectoryAsync(string directoryPath,
+            UmlGenerationOptions options, CancellationToken cancellationToken)
+        {
+            var directoryPaths = Directory.GetFiles(directoryPath, $"*{options.FileExtensionPattern}", new EnumerationOptions()
+            {
+                RecurseSubdirectories = options.DirectoryDepth > 1,
+            });
+
+            var umlObjects = new List<UmlComponent>();
+            var fileCount = 0;
+            foreach (var path in directoryPaths)
+            {
+                var parseFileResult = await ParseFileAsync(path, cancellationToken);
+                if (!parseFileResult.IsSuccessful)
+                {
+                    return parseFileResult.AsType<Tuple<IEnumerable<UmlComponent>, int>>();
+                }
+
+                fileCount++;
+                umlObjects.AddRange(parseFileResult.Value);
+            }
+
+            return outputFactory.Success(new Tuple<IEnumerable<UmlComponent>, int>(umlObjects, fileCount));
+        }
+
+        private async Task<IOutput<IEnumerable<UmlComponent>>> ParseFileAsync(string filePath, CancellationToken cancellationToken)
+        {
+            using var parser = umlParserFactory.CreateParser(filePath, DefaultTokenStateHandler.Instance);
+            var umlComponent = await parser.ParseUmlAsync(cancellationToken);
+
+            return umlComponent == null
+                ? outputFactory.BadRequest<IEnumerable<UmlComponent>>($"Unable to parse component from file {filePath}.")
+                : outputFactory.Success(umlComponent);
+        }
+
+        private IEnumerable<UmlAssociation> GetAssociations(IEnumerable<UmlComponent> components)
+        {
+            var associations = new List<UmlAssociation>();
+            var componentLookup = components.ToDictionary(c => c.Name, c => c);
+            foreach (var construct in componentLookup.Values.OfType<UmlConstruct>())
+            {
+                var inheritanceAssociations = (construct.Inheritance ?? Enumerable.Empty<string>())
+                    .Where(i => componentLookup.TryGetValue(i, out _))
+                    .Select(i => new UmlAssociation()
+                    {
+                        Name = construct.Name,
+                        AssociatedObjectType = i,
+                        AssociationType = UmlAssociationType.Inheritance
+                    });
+                associations.AddRange(inheritanceAssociations);
+
+                var variableAssociations = (construct.Variables ?? Enumerable.Empty<UmlVariable>())
+                    .SelectMany(variable => GetAggregationTypes(variable.Type))
+                    .Where(type => componentLookup.TryGetValue(type, out _))
+                    .Select(type => new UmlAssociation()
+                    {
+                        Name = construct.Name,
+                        AssociatedObjectType = type,
+                        AssociationType = UmlAssociationType.Aggregation
+                    });
+                associations.AddRange(variableAssociations);
+            }
+
+            return associations;
+        }
+
+        private IEnumerable<string> GetAggregationTypes(string type)
+        {
+            type = type.TrimEnd('?');
+            var underlyingTypes = type.Split(new char[] { ',', '<', '>' }, StringSplitOptions.RemoveEmptyEntries);
+
+            return underlyingTypes;
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.UML/Internal/Services/UmlParser.cs
+++ b/src/OSK.UML/Internal/Services/UmlParser.cs
@@ -1,0 +1,255 @@
+﻿using OSK.Parsing.FileTokens.Models;
+using OSK.Parsing.FileTokens.Ports;
+using OSK.UML.Framework.Models;
+using OSK.UML.Framework.Ports;
+using OSK.UML.Models;
+using OSK.UML.Ports;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSK.UML.Internal.Services
+{
+    internal class UmlParser(IFileTokenReader tokenReader, IUmlDefinition umlDefinition)
+        : IUmlParser
+    {
+        #region Variables
+
+        private string _nameSpace;
+
+        #endregion
+
+        #region IUmlParser
+
+        public async Task<IEnumerable<UmlComponent>> ParseUmlAsync(CancellationToken cancellationToken = default)
+        {
+            var components = new List<UmlComponent>();
+
+            while (true)
+            {
+                var component = await ReadUmlComponentAsync(cancellationToken);
+                if (component == null)
+                {
+                    break;
+                }
+
+                components.Add(component);
+            }
+
+            return components;
+        }
+
+        public void Dispose()
+        {
+            tokenReader.Dispose();
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private async Task<UmlComponent> ReadUmlComponentAsync(CancellationToken cancellationToken)
+        {
+            var interpreters = umlDefinition.GetUmlInterpreters();
+            var constructMemberInterpreters = interpreters.Where(i => i.InterpreterType == UmlElementType.Method
+             || i.InterpreterType == UmlElementType.Variable).ToArray();
+            var constructInterpreters = interpreters.Where(i => i.InterpreterType == UmlElementType.Construct)
+                .ToArray();
+            var nameSpaceInterpreter = interpreters.FirstOrDefault(i => i.InterpreterType == UmlElementType.NameSpace);
+
+            while (true)
+            {
+                var fileToken = await tokenReader.ReadTokenAsync(cancellationToken);
+                if (fileToken.TokenType == FileTokenType.EndOfFile)
+                {
+                    return null;
+                }
+                switch (fileToken.TokenType)
+                {
+                    case FileTokenType.Text:
+                    case FileTokenType.EndOfStatement:
+                    case FileTokenType.ClosureStart:
+                        if (nameSpaceInterpreter != null)
+                        {
+                            nameSpaceInterpreter.AddFileToken(fileToken);
+                            if (nameSpaceInterpreter.State == UmlInterpreterState.Satisfied)
+                            {
+                                _nameSpace = nameSpaceInterpreter.GetElement()!.Name;
+                                nameSpaceInterpreter = null;
+                                continue;
+                            }
+                        }
+                        IUmlInterpreter completedInterpreter = null;
+                        foreach (var interpreter in constructInterpreters)
+                        {
+                            interpreter.AddFileToken(fileToken);
+                            if (interpreter.State == UmlInterpreterState.Satisfied)
+                            {
+                                completedInterpreter = interpreter;
+                                break;
+                            }
+                        }
+                        if (completedInterpreter != null)
+                        {
+                            var umlElement = completedInterpreter.GetElement();
+                            var component = umlElement!.ConstructType! switch
+                            {
+                                UmlConstructType.Object => await ReadUmlConstructAsync(umlElement, constructMemberInterpreters, cancellationToken),
+                                UmlConstructType.ValueList => await ReadUmlValueListAsync(umlElement, cancellationToken),
+                                _ => (UmlComponent)null
+                            };
+
+                            if (component == null)
+                            {
+                                throw new InvalidOperationException($"Unable to interpret a uml component with an unexpected file format.");
+                            }
+
+                            return component;
+                        }
+                        break;
+                }
+            }
+        }
+
+        private async Task<UmlConstruct> ReadUmlConstructAsync(UmlElement mainUmlElement,
+            IUmlInterpreter[] memberInterpreters, CancellationToken cancellationToken)
+        {
+            var variables = new List<UmlVariable>();
+            var methods = new List<UmlMethod>();
+            var openClosures = 1;
+
+            var completedInterpreters = new HashSet<int>();
+            while (true)
+            {
+                var fileToken = await tokenReader!.ReadTokenAsync(cancellationToken);
+                if (fileToken.TokenType == FileTokenType.ClosureEnd && openClosures == 0
+                     || fileToken.TokenType == FileTokenType.EndOfFile)
+                {
+                    break;
+                }
+
+                switch (fileToken.TokenType)
+                {
+                    case FileTokenType.Assignment:
+                        await tokenReader.ReadToEndTokenAsync(fileToken, cancellationToken);
+                        break;
+                    case FileTokenType.Text:
+                    case FileTokenType.EndOfStatement:
+                    case FileTokenType.ClosureStart:
+                    case FileTokenType.ClosureEnd:
+                        if (fileToken.TokenType == FileTokenType.ClosureStart)
+                        {
+                            openClosures++;
+                        }
+                        else if (fileToken.TokenType == FileTokenType.ClosureEnd)
+                        {
+                            openClosures--;
+                        }
+
+                        for (var i = 0; i < memberInterpreters.Length; i++)
+                        {
+                            var interpreter = memberInterpreters[i];
+                            interpreter.AddFileToken(fileToken);
+                            if (interpreter.State != UmlInterpreterState.Parsing)
+                            {
+                                completedInterpreters.Add(i);
+                            }
+                        }
+
+                        if (completedInterpreters.Count == memberInterpreters.Length)
+                        {
+                            completedInterpreters.Clear();
+                            IUmlInterpreter umlInterpreter = null;
+                            foreach (var interpreter in memberInterpreters.Where(i => i.State == UmlInterpreterState.Satisfied))
+                            {
+                                if (umlInterpreter == null || interpreter.TotalRules > umlInterpreter.TotalRules)
+                                {
+                                    umlInterpreter = interpreter;
+                                }
+                            }
+                            if (umlInterpreter != null)
+                            {
+                                var umlElement = umlInterpreter.GetElement();
+                                switch (umlElement!.UmlType)
+                                {
+                                    case UmlElementType.Method:
+                                        methods.Add(new UmlMethod()
+                                        {
+                                            Modifiers = umlElement.Modifiers,
+                                            Name = umlElement.Name,
+                                            Type = umlElement.Type,
+                                            Visibility = umlElement.Visibility,
+                                            Parameters = umlElement.Parameters
+                                                .Select(p => new UmlParameter()
+                                                {
+                                                    Name = p.Name,
+                                                    Type = p.Type
+                                                })
+                                        });
+                                        break;
+                                    case UmlElementType.Variable:
+                                        variables.Add(new UmlVariable()
+                                        {
+                                            Modifiers = umlElement.Modifiers,
+                                            Name = umlElement.Name,
+                                            Visibility = umlElement.Visibility,
+                                            Type = umlElement.Type
+                                        });
+                                        break;
+                                }
+                            }
+
+                            foreach (var interpreter in memberInterpreters)
+                            {
+                                interpreter.Reset();
+                            }
+                        }
+                        break;
+                }
+            }
+
+            return new UmlConstruct()
+            {
+                Namespace = _nameSpace,
+                Name = mainUmlElement.Name,
+                Inheritance = mainUmlElement.Inheritance,
+                Modifiers = mainUmlElement.Modifiers,
+                Type = mainUmlElement.Type,
+                Visibility = mainUmlElement.Visibility,
+                Variables = variables,
+                Methods = methods
+            };
+        }
+
+        private async Task<UmlValueList> ReadUmlValueListAsync(UmlElement element, CancellationToken cancellationToken)
+        {
+            var values = new List<string>();
+            while (true)
+            {
+                var fileToken = await tokenReader.ReadTokenAsync(cancellationToken);
+                if (fileToken.TokenType == FileTokenType.ClosureEnd
+                     || fileToken.TokenType == FileTokenType.EndOfFile)
+                {
+                    break;
+                }
+                if (fileToken.TokenType == FileTokenType.Text)
+                {
+                    values.Add(fileToken.ToString());
+                }
+            }
+
+            return new UmlValueList()
+            {
+                Namespace = _nameSpace,
+                Name = element.Name,
+                Modifiers = element.Modifiers,
+                Visibility = element.Visibility,
+                Values = values
+            };
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.UML/Internal/Services/UmlParserFactory.cs
+++ b/src/OSK.UML/Internal/Services/UmlParserFactory.cs
@@ -1,0 +1,13 @@
+﻿using OSK.Parsing.FileTokens.Ports;
+using OSK.UML.Ports;
+
+namespace OSK.UML.Internal.Services
+{
+    internal class UmlParserFactory : IUmlParserFactory
+    {
+        public IUmlParser CreateParser(string path, ITokenStateHandler tokenStateHandler)
+        {
+            return UmlFileReader.OpenRead(path, tokenStateHandler);
+        }
+    }
+}

--- a/src/OSK.UML/Models/UmlAssociation.cs
+++ b/src/OSK.UML/Models/UmlAssociation.cs
@@ -1,0 +1,18 @@
+﻿namespace OSK.UML.Models
+{    
+    // Comment 1
+    /// <summary>
+    /// Comment 2
+    /// </summary>
+    /*
+     * Comment 3 
+     */
+    public class UmlAssociation
+    {
+        public string Name { get; set; }
+
+        public string AssociatedObjectType { get; set; }
+
+        public UmlAssociationType AssociationType { get; set; }
+    }
+}

--- a/src/OSK.UML/Models/UmlAssociationType.cs
+++ b/src/OSK.UML/Models/UmlAssociationType.cs
@@ -1,0 +1,8 @@
+﻿namespace OSK.UML.Models
+{
+    public enum UmlAssociationType
+    {
+        Aggregation,
+        Inheritance
+    }
+}

--- a/src/OSK.UML/Models/UmlComponent.cs
+++ b/src/OSK.UML/Models/UmlComponent.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace OSK.UML.Models
+{
+    public abstract class UmlComponent
+    {
+        public string Namespace { get; set; }
+
+        public string Name { get; set; }
+
+        public string Visibility { get; set; }
+
+        public IEnumerable<string> Modifiers { get; set; }
+    }
+}

--- a/src/OSK.UML/Models/UmlConstruct.cs
+++ b/src/OSK.UML/Models/UmlConstruct.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace OSK.UML.Models
+{
+    public class UmlConstruct : UmlComponent
+    {
+        public string Type { get; set; }
+
+        public IEnumerable<string> Inheritance { get; set; }
+
+        public IEnumerable<UmlVariable> Variables { get; set; }
+
+        public IEnumerable<UmlMethod> Methods { get; set; }
+    }
+}

--- a/src/OSK.UML/Models/UmlConstructMember.cs
+++ b/src/OSK.UML/Models/UmlConstructMember.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace OSK.UML.Models
+{
+    public abstract class UmlConstructMember
+    {
+        public string Name { get; set; }
+
+        public string Type { get; set; }
+
+        public string Visibility { get; set; }
+
+        public IEnumerable<string> Modifiers { get; set; }
+    }
+}

--- a/src/OSK.UML/Models/UmlDiagram.cs
+++ b/src/OSK.UML/Models/UmlDiagram.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace OSK.UML.Models
+{
+    public class UmlDiagram
+    {
+        public string Name { get; set; }
+
+        public IEnumerable<UmlComponent> UmlObjects { get; set; }
+
+        public IEnumerable<UmlAssociation> UmlAssociations { get; set; }
+    }
+}

--- a/src/OSK.UML/Models/UmlGenerationResult.cs
+++ b/src/OSK.UML/Models/UmlGenerationResult.cs
@@ -1,0 +1,11 @@
+﻿namespace OSK.UML.Models
+{
+    public class UmlGenerationResult
+    {
+        public int TotalFilesChecked { get; set; }
+
+        public int TotalUmlObjectsDiscovered { get; set; }
+
+        public UmlDiagram UmlDiagram { get; set; }
+    }
+}

--- a/src/OSK.UML/Models/UmlMethod.cs
+++ b/src/OSK.UML/Models/UmlMethod.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace OSK.UML.Models
+{
+    public class UmlMethod : UmlConstructMember
+    {
+        public IEnumerable<UmlParameter> Parameters { get; set; }
+    }
+}

--- a/src/OSK.UML/Models/UmlParameter.cs
+++ b/src/OSK.UML/Models/UmlParameter.cs
@@ -1,0 +1,9 @@
+﻿namespace OSK.UML.Models
+{
+    public class UmlParameter
+    {
+        public string Name { get; set; }
+
+        public string Type { get; set; }
+    }
+}

--- a/src/OSK.UML/Models/UmlValueList.cs
+++ b/src/OSK.UML/Models/UmlValueList.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace OSK.UML.Models
+{
+    public class UmlValueList : UmlComponent
+    {
+        public IEnumerable<string> Values { get; set; }
+    }
+}

--- a/src/OSK.UML/Models/UmlVariable.cs
+++ b/src/OSK.UML/Models/UmlVariable.cs
@@ -1,0 +1,6 @@
+﻿namespace OSK.UML.Models
+{
+    public class UmlVariable : UmlConstructMember
+    {
+    }
+}

--- a/src/OSK.UML/OSK.UML.csproj
+++ b/src/OSK.UML/OSK.UML.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<LangVersion>12</LangVersion>
+		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.UML</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<Description>A .NET library that provides logic for parsing files or directories into UML diagrams.</Description>
+		<PackageTags>OpenSourceKingdom, OpenSource, OSK, parsing, file, directory, reader, parse, uml, diagram</PackageTags>
+		<Authors>BlankDev117</Authors>
+		<Title>OSK.UML</Title>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+		<PackageReference Include="OSK.Functions.Outputs.Logging.Abstractions" Version="1.4.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\OSK.UML.Framework\OSK.UML.Framework.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.UML/Options/UmlGenerationOptions.cs
+++ b/src/OSK.UML/Options/UmlGenerationOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace OSK.UML.Options
+{
+    public class UmlGenerationOptions
+    {
+        public int DirectoryDepth { get; set; }
+
+        public string FileExtensionPattern = "*.cs";
+    }
+}

--- a/src/OSK.UML/Ports/IUmlExporter.cs
+++ b/src/OSK.UML/Ports/IUmlExporter.cs
@@ -1,0 +1,12 @@
+﻿using OSK.Functions.Outputs.Abstractions;
+using OSK.UML.Models;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSK.UML.Ports
+{
+    public interface IUmlExporter
+    {
+        Task<IOutput> ExportAsync(string path, UmlDiagram diagram, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/OSK.UML/Ports/IUmlGenerator.cs
+++ b/src/OSK.UML/Ports/IUmlGenerator.cs
@@ -1,0 +1,13 @@
+﻿using OSK.Functions.Outputs.Abstractions;
+using OSK.UML.Models;
+using OSK.UML.Options;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSK.UML.Ports
+{
+    public interface IUmlGenerator
+    {
+        Task<IOutput<UmlGenerationResult>> GenerateUmlAsync(string path, string domainName, UmlGenerationOptions options, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/OSK.UML/Ports/IUmlParser.cs
+++ b/src/OSK.UML/Ports/IUmlParser.cs
@@ -1,0 +1,13 @@
+﻿using OSK.UML.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSK.UML.Ports
+{
+    public interface IUmlParser : IDisposable
+    {
+        Task<IEnumerable<UmlComponent>> ParseUmlAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/OSK.UML/Ports/IUmlParserFactory.cs
+++ b/src/OSK.UML/Ports/IUmlParserFactory.cs
@@ -1,0 +1,9 @@
+﻿using OSK.Parsing.FileTokens.Ports;
+
+namespace OSK.UML.Ports
+{
+    public interface IUmlParserFactory
+    {
+        IUmlParser CreateParser(string path, ITokenStateHandler tokenStateHandler);
+    }
+}

--- a/src/OSK.UML/Properties/Assembly.cs
+++ b/src/OSK.UML/Properties/Assembly.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OSK.UML.UnitTests")]

--- a/src/OSK.UML/ServiceCollectionExtensions.cs
+++ b/src/OSK.UML/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OSK.UML.Internal.Services;
+using OSK.UML.Ports;
+
+namespace OSK.UML
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddUmlDiagrams(this IServiceCollection services)
+        {
+            services.TryAddTransient<IUmlParserFactory, UmlParserFactory>();
+            services.TryAddTransient<IUmlGenerator, DefaultUmlGenerator>();
+
+            return services;
+        }
+    }
+}

--- a/src/OSK.UML/UmlFileReader.cs
+++ b/src/OSK.UML/UmlFileReader.cs
@@ -1,0 +1,26 @@
+﻿using OSK.Parsing.FileTokens;
+using OSK.Parsing.FileTokens.Handlers;
+using OSK.Parsing.FileTokens.Ports;
+using OSK.UML.Framework.Definitions;
+using OSK.UML.Framework.Ports;
+using OSK.UML.Ports;
+
+namespace OSK.UML
+{
+    public static class UmlFileReader
+    {
+        public static IUmlParser OpenRead(string filePath)
+            => OpenRead(filePath, DefaultTokenStateHandler.Instance);
+
+        public static IUmlParser OpenRead(string filePath,
+            ITokenStateHandler tokenStateHandler)
+            => OpenRead(filePath, tokenStateHandler, DefaultUmlDefinition.Instance);
+
+        public static IUmlParser OpenRead(string filePath, ITokenStateHandler tokenStateHandler,
+            IUmlDefinition umlDefinition)
+        {
+            var tokenReader = FileTokenParser.OpenRead(filePath, tokenStateHandler);
+            return new Internal.Services.UmlParser(tokenReader, umlDefinition);
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----
Having a quick and easy way to generate UML diagrams for a variety of files may be helpful to developers

Modifications
----
* Added github workflows
* Added dockerfiles
* Added project
* Added UnitTests

Result
----
An easy to use command line tool should now be available that can generate UML diagrams directly from a file or folder and should be easily configurable to the syntax of most languages

Fixes #1