### PR TITLE
Remove readme from command line (OSK-6)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,5 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>CS1591</NoWarn>
 		<Authors>BlankDev117</Authors>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 </Project>

--- a/src/OSK.UML.CommandLine/OSK.UML.CommandLine.csproj
+++ b/src/OSK.UML.CommandLine/OSK.UML.CommandLine.csproj
@@ -20,7 +20,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
 		<ProjectReference Include="..\OSK.UML.Exporters.PlantUML\OSK.UML.Exporters.PlantUML.csproj" />
 		<ProjectReference Include="..\OSK.UML\OSK.UML.csproj" />
 	</ItemGroup>

--- a/src/OSK.UML.Exporters.PlantUML/OSK.UML.Exporters.PlantUML.csproj
+++ b/src/OSK.UML.Exporters.PlantUML/OSK.UML.Exporters.PlantUML.csproj
@@ -5,6 +5,7 @@
 		<Description>A .NET library that provides a uml diagram exporter that is based on an integration with PlantUML.</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, OSK, parsing, uml, diagram, export, plant</PackageTags>
 		<Title>OSK.UML.Exporters.PlantUML</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/OSK.UML.Framework/OSK.UML.Framework.csproj
+++ b/src/OSK.UML.Framework/OSK.UML.Framework.csproj
@@ -5,6 +5,7 @@
 		<Description>A .NET library that provides a foundational framework for parsing files or directories into UML diagrams.</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, OSK, parsing, file, directory, reader, parse, uml, diagram, framework, analsis, tool, generator, definition, syntax, template</PackageTags>
 		<Title>OSK.UML.Framework</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/OSK.UML/OSK.UML.csproj
+++ b/src/OSK.UML/OSK.UML.csproj
@@ -5,6 +5,7 @@
 		<Description>A .NET library that provides logic for parsing files or directories into UML diagrams.</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, OSK, parsing, file, directory, reader, parse, uml, diagram, project, class, analysis, generator, dependency, tool</PackageTags>
 		<Title>OSK.UML</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
Motivation
----
Build failed due to improper readme

Modifications
----
* Remove readme from CommandLine

Result
----
should build

Fixes #6